### PR TITLE
fix: adjust the api doc endpoint to only run once in tests for now

### DIFF
--- a/cmd/sheltertech-go/integration_test.go
+++ b/cmd/sheltertech-go/integration_test.go
@@ -64,6 +64,7 @@ func TestPostServicesChangeRequest(t *testing.T) {
 }
 
 func TestSwaggerDocs(t *testing.T) {
+	viper.SetDefault("SERVE_DOCS", "true")
 	startServer()
 
 	url := "http://localhost:3002/swagger/index.html"
@@ -75,6 +76,7 @@ func TestSwaggerDocs(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
+	viper.SetDefault("SERVE_DOCS", "false")
 }
 
 func TestPrometheusMetrics(t *testing.T) {

--- a/cmd/sheltertech-go/main.go
+++ b/cmd/sheltertech-go/main.go
@@ -33,8 +33,8 @@ import (
 
 //	@securityDefinitions.basic	BasicAuth
 
-//	@externalDocs.description	OpenAPI
-//	@externalDocs.url			https://swagger.io/resources/open-api/
+// @externalDocs.description	OpenAPI
+// @externalDocs.url			https://swagger.io/resources/open-api/
 func main() {
 
 	viper.AutomaticEnv()
@@ -43,6 +43,7 @@ func main() {
 	dbPort := viper.GetString("DB_PORT")
 	dbName := viper.GetString("DB_NAME")
 	dbPass := viper.GetString("DB_PASS")
+	serveDocs := viper.GetBool("SERVE_DOCS")
 
 	dbManager := db.New(dbHost, dbPort, dbName, dbUser, dbPass)
 	categoriesManager := categories.New(dbManager)
@@ -67,10 +68,12 @@ func main() {
 	docs.SwaggerInfo.BasePath = "/v2"
 	docs.SwaggerInfo.Schemes = []string{"http", "https"}
 
-	rg := gin.Default()
-	rg.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	go rg.Run(":3002")
-
+	if serveDocs {
+		gin.SetMode(gin.ReleaseMode)
+		rg := gin.Default()
+		rg.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+		go rg.Run(":3002")
+	}
 
 	http.ListenAndServe(":3001", r)
 }


### PR DESCRIPTION
This cleans up the test output for now, I need to find a more graceful way to allow the other port needed for the api docs to work cleanly in test suite, or serve it off the same port as the rest of the api.