### PR TITLE
Small bug fix to add 'categories' prefix to the Get categories response. Moved manager.go out of heather/categoriesTest. 

### DIFF
--- a/internal/categories/manager.go
+++ b/internal/categories/manager.go
@@ -51,6 +51,7 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("%v", err)
 	}
+	// return json with 'categories' prefix
 	dbCategory := m.DbClient.GetCategoryByID(categoryId)
 	writeJson(w, fromDBType(dbCategory))
 }

--- a/internal/categories/manager.go
+++ b/internal/categories/manager.go
@@ -43,7 +43,10 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 		topLevel = &topLevelBool
 	}
 	dbCategories := m.DbClient.GetCategories(topLevel)
-	writeJson(w, fromDBTypeArray(dbCategories))
+	response := Categories{
+		Categories: fromDBTypeArray(dbCategories),
+	}
+	writeJson(w, response)
 }
 
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +54,6 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("%v", err)
 	}
-	// return json with 'categories' prefix
 	dbCategory := m.DbClient.GetCategoryByID(categoryId)
 	writeJson(w, fromDBType(dbCategory))
 }


### PR DESCRIPTION
"categories" prefix added to json response.
GetByFeatured has the prefix. The prefix is currently **not** returned with GetById or GetSubCategoriesByID.

to check, hit http://localhost:3001/api/categories 
_also_, http://localhost:3001/api/categories/featured