### PR TITLE
feat: allow hot reload for dev flow

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -1,0 +1,41 @@
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./tmp/sheltertech-go-hot ./cmd/sheltertech-go"
+# Binary file yields from `cmd`.
+bin = "./tmp/sheltertech-go-hot"
+# Customize binary.
+full_bin = "./tmp/sheltertech-go-hot"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop to run old binary when build errors occur.
+stop_on_error = true
+# This log file places in your tmp_dir.
+log = "air_errors.log"
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/tmp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM golang:1.22
+
+WORKDIR /app
+
+EXPOSE 3001
+
+CMD [ "/app/tmp/sheltertech-go" ]

--- a/Dockerfile.hot.dev
+++ b/Dockerfile.hot.dev
@@ -1,0 +1,5 @@
+FROM golang:1.22
+RUN go install github.com/air-verse/air@latest
+WORKDIR /app
+EXPOSE 3001
+CMD ["air", "-c", ".air.conf"]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ fmt:
 	@gofmt -l -w $(SRC)
 
 run:
-	docker-compose build && docker-compose up
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./tmp/sheltertech-go ./cmd/sheltertech-go && DOCKER_DEFAULT_PLATFORM="linux/amd64" docker-compose -f docker-compose.dev.yml build && docker-compose -f docker-compose.dev.yml up
+
+hot-run:
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./tmp/sheltertech-go-hot ./cmd/sheltertech-go && DOCKER_DEFAULT_PLATFORM="linux/amd64" docker-compose -f docker-compose.hot.dev.yml build && docker-compose -f docker-compose.hot.dev.yml up
 
 ci-run:
 	docker-compose -f docker-compose.ci.yml build && docker-compose -f docker-compose.ci.yml up -d

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,8 +3,8 @@ version: "3.5"
 services:
   sheltertech-go:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ./
+      dockerfile: Dockerfile.dev
     environment:
       DB_HOST: db
       DB_PORT: 5432
@@ -13,6 +13,8 @@ services:
       AUTH0_DOMAIN: "dev-nykixf8szsm220fi.us.auth0.com"
     networks:
       - askdarcel
+    volumes:
+      - ./:/app
     ports:
       - "3001:3001"
       - "3002:3002"

--- a/docker-compose.hot.dev.yml
+++ b/docker-compose.hot.dev.yml
@@ -1,0 +1,25 @@
+version: "3.5"
+
+services:
+  sheltertech-go:
+    build:
+      context: ./
+      dockerfile: Dockerfile.hot.dev
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: askdarcel_development
+      DB_USER: postgres
+      AUTH0_DOMAIN: "dev-nykixf8szsm220fi.us.auth0.com"
+    networks:
+      - askdarcel
+    volumes:
+      - ./:/app
+    ports:
+      - "3001:3001"
+      - "3002:3002"
+
+networks:
+  # Used to connect to askdarcel in a different docker-compose instance
+  askdarcel:
+    name: askdarcel


### PR DESCRIPTION
There are changes to `make run`

This will recompile the binary locally and not change the docker image, so this should launch quicker than rebuilding the image

There is a new target `make hot-run`

This uses a hot-recompiling in place utility to auto update on changes to Go source code.