### PR TITLE
folders: Fix duplicated JSON body in POST response.

### DIFF
--- a/internal/folders/manager.go
+++ b/internal/folders/manager.go
@@ -84,8 +84,7 @@ func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	if dbFolder == nil {
 		// This really shouldn't happen, since we just created it.
 		writeStatus(w, http.StatusInternalServerError)
-	} else {
-		writeJson(w, FromDBType(dbFolder))
+		return
 	}
 
 	writeStatus(w, http.StatusCreated)


### PR DESCRIPTION
We were calling `writeJson()` twice, which was causing the JSON data to be duplicated in the response body, which makes it illegal JSON.

This is probably my fault and not @katerina-kossler's, since I think I was the one who added this code to return the newly created folder in the API response.

I tried to write a unit test, but I can't get it to work because we don't have an API endpoint that allows you to create a user, since that endpoint requires you to construct a legal Auth0 JWT, which is impossible for us to do cryptographically. Even if we don't have auth hooked up yet to these endpoints, you still end up failing the foreign key constraint between folders and users if there are no legal user IDs to use in the foreign key on the folders table.