### PR TITLE
users: Return non-successful status code when failing auth.

### DIFF
--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -27,6 +27,7 @@ func New(dbManager *db.Manager, jwtKeyfunc keyfunc.Keyfunc) *Manager {
 func (m *Manager) GetCurrent(w http.ResponseWriter, r *http.Request) {
 	dbUser, err := auth.GetUserFromRequest(r, m.JwtKeyfunc, m.DbClient)
 	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
 		writeJson(w, ApiError{err.Error()})
 		return
 	}


### PR DESCRIPTION
Because `writeJson()` was returning a 200, it made errors look as if they were successful, which was throwing off logic in the frontend app. This makes any failure return a 400 code.