### PR TITLE
Add name col/field  to bookmarks api endpoints

### DIFF
--- a/db/data.sql
+++ b/db/data.sql
@@ -187,6 +187,7 @@ CREATE TABLE public.bookmarks (
     identifier character varying,
     date_value timestamp without time zone,
     id_value integer,
+    name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );

--- a/internal/bookmarks/manager.go
+++ b/internal/bookmarks/manager.go
@@ -98,6 +98,7 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 		ServiceID:  bookmark.ServiceID,
 		ResourceID: bookmark.ResourceID,
 		UserID:     bookmark.UserID,
+		Name:       bookmark.Name,
 	}
 
 	err = m.DbClient.SubmitBookmark(dbBookmark)
@@ -130,6 +131,7 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 		ServiceID:  bookmark.ServiceID,
 		ResourceID: bookmark.ResourceID,
 		UserID:     bookmark.UserID,
+		Name:       bookmark.Name,
 	}
 
 	err = m.DbClient.UpdateBookmark(dbBookmark)

--- a/internal/bookmarks/types.go
+++ b/internal/bookmarks/types.go
@@ -9,6 +9,7 @@ type Bookmark struct {
 	ServiceID  *int `json:"service_id"`
 	ResourceID *int `json:"resource_id"`
 	UserID     *int `json:"user_id"`
+	Name      string `json:"name"`
 }
 
 type Bookmarks struct {
@@ -23,6 +24,7 @@ func FromDBType(dbBookmark *db.Bookmark) *Bookmark {
 		ResourceID: dbBookmark.ResourceID,
 		UserID:     dbBookmark.UserID,
 		FolderID:   dbBookmark.FolderID,
+		Name:       dbBookmark.Name,
 	}
 	return bookmark
 }

--- a/internal/db/bookmarks.go
+++ b/internal/db/bookmarks.go
@@ -14,27 +14,26 @@ type Bookmark struct {
 	ServiceID  *int
 	ResourceID *int
 	UserID     *int
+	Name	   string
 	CreatedAt  sql.NullTime
 	UpdatedAt  sql.NullTime
 }
 
 const findBookmarksSql = `
-SELECT id, "order", user_id, folder_id, service_id, resource_id from public.bookmarks`
+SELECT id, "order", user_id, folder_id, service_id, resource_id, name from public.bookmarks`
 
 const findBookmarksByUserIDSql = `
-SELECT id, "order", user_id, folder_id, service_id, resource_id from public.bookmarks 
-WHERE user_id=$1`
+SELECT id, "order", user_id, folder_id, service_id, resource_id, name from public.bookmarks WHERE user_id=$1`
 
 const findBookmarksByIDSql = `
-SELECT id, "order", user_id, folder_id, service_id, resource_id from public.bookmarks 
-WHERE id=$1`
+SELECT id, "order", user_id, folder_id, service_id, resource_id, name from public.bookmarks WHERE id=$1`
 
 const submitBookmark = `
-INSERT INTO public.bookmarks ("order", user_id, folder_id, resource_id, service_id, created_at, updated_at)
-VALUES ($1, $2, $3, $4, $5, now(), now())`
+INSERT INTO public.bookmarks ("order", user_id, folder_id, resource_id, service_id, name, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, now(), now())`
 
 const updateBookmark = `
-UPDATE public.bookmarks SET "order" = $2, user_id = $3, folder_id= $4, resource_id = $5, service_id = $6 where id = $1`
+UPDATE public.bookmarks SET "order" = $2, user_id = $3, folder_id= $4, resource_id = $5, service_id = $6, name = $7 where id = $1`
 
 const deleteBookmarkByIDSql = `
 DELETE FROM public.bookmarks WHERE id = $1
@@ -77,7 +76,7 @@ func (m *Manager) SubmitBookmark(bookmark *Bookmark) error {
 	if err != nil {
 		return err
 	}
-	res, err := tx.Exec(submitBookmark, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID)
+	res, err := tx.Exec(submitBookmark, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID, bookmark.Name)
 	if err != nil {
 		return err
 	}
@@ -99,7 +98,7 @@ func (m *Manager) UpdateBookmark(bookmark *Bookmark) error {
 	if err != nil {
 		return err
 	}
-	res, err := tx.Exec(updateBookmark, bookmark.Id, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID)
+	res, err := tx.Exec(updateBookmark, bookmark.Id, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID, bookmark.Name)
 	if err != nil {
 		return err
 	}
@@ -140,7 +139,7 @@ func scanBookmarks(rows *sql.Rows) []*Bookmark {
 	var bookmarks []*Bookmark
 	for rows.Next() {
 		var bookmark Bookmark
-		err := rows.Scan(&bookmark.Id, &bookmark.Order, &bookmark.UserID, &bookmark.FolderID, &bookmark.ServiceID, &bookmark.ResourceID)
+		err := rows.Scan(&bookmark.Id, &bookmark.Order, &bookmark.UserID, &bookmark.FolderID, &bookmark.ServiceID, &bookmark.ResourceID, &bookmark.Name)
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
@@ -153,6 +152,6 @@ func scanBookmarks(rows *sql.Rows) []*Bookmark {
 
 func scanBookmark(row *sql.Row) (*Bookmark, error) {
 	var bookmark Bookmark
-	err := row.Scan(&bookmark.Id, &bookmark.Order, &bookmark.UserID, &bookmark.FolderID, &bookmark.ServiceID, &bookmark.ResourceID)
+	err := row.Scan(&bookmark.Id, &bookmark.Order, &bookmark.UserID, &bookmark.FolderID, &bookmark.ServiceID, &bookmark.ResourceID, &bookmark.Name)
 	return &bookmark, err
 }


### PR DESCRIPTION
part of: [#127](https://github.com/ShelterTechSF/sheltertech-go/issues/127)

changes: 
- add name to bookmark-related endpoints
- include col in db setup for docker image

notes:
-  io/ioutil package depreciated. seems like same func is with packaged with io. See: https://pkg.go.dev/io/ioutil#ReadAll vs. https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/io/io.go;l=709 . Do we want to fix this in future PR or is this use intentional?
- do not merge until [API change](https://github.com/ShelterTechSF/askdarcel-api/pull/753) is merged and applied to db