### PR TITLE
fix: datathon queries

### DIFF
--- a/internal/changerequest/manager.go
+++ b/internal/changerequest/manager.go
@@ -36,11 +36,11 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 	switch changeRequest.Type {
 	case "ServiceChangeRequest":
 		service, err = m.DbClient.GetServiceById(changeRequest.ObjectID)
-			if err != nil {
+		if err != nil {
 			log.Printf("%v", err)
 			common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
-		return	
-	}
+			return
+		}
 		break
 	}
 	if err != nil || service == nil {

--- a/internal/db/datathon.go
+++ b/internal/db/datathon.go
@@ -31,7 +31,7 @@ WHERE (s.id IN
          FROM public.categories_services a
          LEFT JOIN public.services b ON a.service_id = b.id
          WHERE a.category_id IN
-           (SELECT id
+           (SELECT child_id
             FROM public.category_relationships
             WHERE parent_id IN (1000001,1000002,1000003,1000004,1000005,1000006,1000007,1000008,1000009,1000010,1000011,1000012))
           AND b.status = 1))
@@ -53,7 +53,7 @@ WHERE (s.id NOT IN
          FROM public.categories_services a
          LEFT JOIN public.services b ON a.service_id = b.id
          WHERE a.category_id IN
-           (SELECT id
+           (SELECT child_id
             FROM public.category_relationships
             WHERE parent_id IN (1000001,1000002,1000003,1000004,1000005,1000006,1000007,1000008,1000009,1000010,1000011,1000012))
           AND b.status = 1))

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/sheltertechsf/sheltertech-go/internal/addresses"
 	"github.com/sheltertechsf/sheltertech-go/internal/categories"
+	"github.com/sheltertechsf/sheltertech-go/internal/common"
 	"github.com/sheltertechsf/sheltertech-go/internal/db"
 	"github.com/sheltertechsf/sheltertech-go/internal/documents"
 	"github.com/sheltertechsf/sheltertech-go/internal/eligibilities"
@@ -17,7 +18,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"github.com/sheltertechsf/sheltertech-go/internal/common"	
 )
 
 type Manager struct {
@@ -45,13 +45,13 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
-		return		
+		return
 	}
 	dbService, err := m.DbClient.GetServiceById(serviceId)
 	if err != nil {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
-		return		
+		return
 	}
 	response := FromDBType(dbService)
 	response.Categories = categories.FromDBTypeArray(m.DbClient.GetCategoriesByServiceID(serviceId))


### PR DESCRIPTION
Opps
```
askdarcel=> \d category_relationships
             Table "public.category_relationships"
       Column        |  Type   | Collation | Nullable | Default 
---------------------+---------+-----------+----------+---------
 parent_id           | integer |           | not null | 
 child_id            | integer |           | not null | 
 child_priority_rank | integer |           |          | 
Indexes:
    "index_category_relationships_on_child_id_and_parent_id" UNIQUE, btree (child_id, parent_id)
```
I used "id" instead of child_id