### PR TITLE
fix: add missing return statements after error responses in handlers

### DIFF
--- a/internal/changerequest/manager.go
+++ b/internal/changerequest/manager.go
@@ -29,7 +29,8 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 	changeRequest := &ChangeRequest{}
 	err := json.Unmarshal(body, changeRequest)
 	if err != nil {
-		writeStatus(w, http.StatusInternalServerError)
+		writeStatus(w, http.StatusBadRequest)
+		return
 	}
 
 	var service *db.Service
@@ -41,10 +42,10 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 			common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		break
 	}
 	if err != nil || service == nil {
 		writeStatus(w, http.StatusInternalServerError)
+		return
 	}
 
 	dBChangeRequest := &db.ChangeRequest{
@@ -59,6 +60,7 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Print(err)
 		writeStatus(w, http.StatusInternalServerError)
+		return
 	}
 
 	writeStatus(w, http.StatusCreated)

--- a/internal/folders/manager.go
+++ b/internal/folders/manager.go
@@ -65,7 +65,8 @@ func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	folder := &Folder{}
 	err := json.Unmarshal(body, folder)
 	if err != nil {
-		writeStatus(w, http.StatusInternalServerError)
+		writeStatus(w, http.StatusBadRequest)
+		return
 	}
 
 	dbFolder := &db.Folder{
@@ -137,7 +138,8 @@ func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 	folder := &Folder{}
 	err := json.Unmarshal(body, folder)
 	if err != nil {
-		writeStatus(w, http.StatusInternalServerError)
+		writeStatus(w, http.StatusBadRequest)
+		return
 	}
 
 	dBFolder := &db.Folder{
@@ -150,6 +152,7 @@ func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Print(err)
 		writeStatus(w, http.StatusInternalServerError)
+		return
 	}
 
 	writeStatus(w, http.StatusCreated)
@@ -170,11 +173,14 @@ func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 	folderId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		log.Printf("%v", err)
+		writeStatus(w, http.StatusBadRequest)
+		return
 	}
 	err = m.DbClient.DeleteFolderById(folderId)
 	if err != nil {
 		log.Print(err)
 		writeStatus(w, http.StatusInternalServerError)
+		return
 	}
 
 	writeStatus(w, http.StatusNoContent)


### PR DESCRIPTION
Several HTTP handlers wrote error status codes but did not return, allowing execution to fall through into subsequent logic with invalid or nil data. This could cause nil pointer dereferences, double WriteHeader calls, and incorrect status codes being sent to clients.

Affected handlers:
- folders Post/Put/Delete
- changerequest Submit

Also corrects json.Unmarshal errors from 500 to 400 (Bad Request), since malformed client input is not a server error.