### PR TITLE
docs: complete Swagger API documentation for all endpoints

### DIFF
--- a/cmd/sheltertech-go/main.go
+++ b/cmd/sheltertech-go/main.go
@@ -31,25 +31,12 @@ import (
 	httpSwagger "github.com/swaggo/http-swagger"
 )
 
-//	@title			Swagger Example API
+//	@title			ShelterTech API
 //	@version		1.0
-//	@description	This is a sample server celler server.
-//	@termsOfService	http://swagger.io/terms/
+//	@description	API for the ShelterTech SF Service Guide application.
 
-//	@contact.name	API Support
-//	@contact.url	http://www.swagger.io/support
-//	@contact.email	support@swagger.io
-
-//	@license.name	Apache 2.0
-//	@license.url	http://www.apache.org/licenses/LICENSE-2.0.html
-
-//	@host		localhost:8080
-//	@BasePath	/api/v1
-
-//	@securityDefinitions.basic	BasicAuth
-
-// @externalDocs.description	OpenAPI
-// @externalDocs.url			https://swagger.io/resources/open-api/
+//	@host		localhost:3001
+//	@BasePath	/api
 func main() {
 
 	viper.AutomaticEnv()
@@ -99,11 +86,11 @@ func main() {
 	}
 
 	sentryHandler := sentryhttp.New(sentryhttp.Options{})
-	docs.SwaggerInfo.Title = "Swagger Example API"
-	docs.SwaggerInfo.Description = "This is a sample server Petstore server."
+	docs.SwaggerInfo.Title = "ShelterTech API"
+	docs.SwaggerInfo.Description = "API for the ShelterTech SF Service Guide application."
 	docs.SwaggerInfo.Version = "1.0"
-	docs.SwaggerInfo.Host = "petstore.swagger.io"
-	docs.SwaggerInfo.BasePath = "/v2"
+	docs.SwaggerInfo.Host = "localhost:3001"
+	docs.SwaggerInfo.BasePath = "/api"
 	docs.SwaggerInfo.Schemes = []string{"http", "https"}
 
 	r := chi.NewRouter()

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -10,21 +10,218 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "termsOfService": "http://swagger.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "url": "http://www.swagger.io/support",
-            "email": "support@swagger.io"
-        },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
+        "contact": {},
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/bookmarks": {
+            "get": {
+                "description": "get all bookmarks, optionally filtered by user_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Get Bookmarks",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Filter by user ID",
+                        "name": "user_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmarks"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new bookmark",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Create Bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark object",
+                        "name": "bookmark",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/bookmarks/{id}": {
+            "get": {
+                "description": "get a single bookmark by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Get Bookmark by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "update an existing bookmark by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Update Bookmark",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Bookmark object",
+                        "name": "bookmark",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a bookmark by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Delete Bookmark",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "description": "get all categories",
@@ -38,14 +235,166 @@ const docTemplate = `{
                     "categories"
                 ],
                 "summary": "Get Categories",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter to top-level categories only",
+                        "name": "top_level",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/counts": {
+            "get": {
+                "description": "get service and resource counts for each category",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Category Counts",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/categories.Categories"
+                                "$ref": "#/definitions/categories.CategoryCountDTO"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/featured": {
+            "get": {
+                "description": "get all featured categories",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Featured Categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/subcategories/{id}": {
+            "get": {
+                "description": "get subcategories for a given parent category ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Subcategories by Category ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Parent Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/{id}": {
+            "get": {
+                "description": "get a single category by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Category"
+                        }
+                    }
+                }
+            }
+        },
+        "/change_requests": {
+            "post": {
+                "description": "create a new change request (e.g. for phones)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "change_requests"
+                ],
+                "summary": "Create Change Request",
+                "parameters": [
+                    {
+                        "description": "Change request payload",
+                        "name": "change_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.ChangeRequestPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.PhoneChangeRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -54,21 +403,41 @@ const docTemplate = `{
         "/datathon/content_curation_dataset": {
             "get": {
                 "description": "gives a csv of the content curation dataset",
+                "produces": [
+                    "text/csv"
+                ],
                 "tags": [
                     "datathon"
                 ],
                 "summary": "Get Content Curation Dataset",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "CSV data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/datathon/datathon_dataset": {
             "get": {
                 "description": "gives a csv of the datathon dataset",
+                "produces": [
+                    "text/csv"
+                ],
                 "tags": [
                     "datathon"
                 ],
                 "summary": "Get Datathon Dataset",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "CSV data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/eligibilities": {
@@ -267,15 +636,24 @@ const docTemplate = `{
                     "folders"
                 ],
                 "summary": "Get Folders for current User",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/folders.Folders"
-                            }
+                            "$ref": "#/definitions/folders.Folders"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
                     }
                 }
             },
@@ -291,12 +669,29 @@ const docTemplate = `{
                     "folders"
                 ],
                 "summary": "Create Folder for current User",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "description": "Folder object",
+                        "name": "folder",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/folders.Folder"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             }
@@ -314,12 +709,27 @@ const docTemplate = `{
                     "folders"
                 ],
                 "summary": "Get folder by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
                     }
                 }
             },
@@ -335,12 +745,33 @@ const docTemplate = `{
                     "folders"
                 ],
                 "summary": "Update folder by ID",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Folder object",
+                        "name": "folder",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             },
@@ -349,18 +780,301 @@ const docTemplate = `{
                 "consumes": [
                     "application/json"
                 ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "folders"
                 ],
                 "summary": "Delete folder by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/news_articles": {
+            "get": {
+                "description": "Get all news articles with optional filtering for active articles only",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Get News Articles",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter for active news articles only",
+                        "name": "active",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/folders.Folder"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/newsarticles.NewsArticle"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new news article",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Create News Article",
+                "parameters": [
+                    {
+                        "description": "News article data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticleCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticle"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/news_articles/{id}": {
+            "put": {
+                "description": "Update an existing news article",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Update News Article",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "News Article ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "News article update data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticleUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticle"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {}
+                    },
+                    "404": {
+                        "description": "News article not found",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an existing news article",
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Delete News Article",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "News Article ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty response on success",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid news article ID format",
+                        "schema": {}
+                    },
+                    "404": {
+                        "description": "News article not found",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/phones/{id}": {
+            "delete": {
+                "description": "delete a phone record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "phones"
+                ],
+                "summary": "Delete Phone",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Phone ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/phones/{id}/change_requests": {
+            "post": {
+                "description": "create a change request to update phone fields",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "change_requests"
+                ],
+                "summary": "Update Phone Change Request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Phone ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Change request payload",
+                        "name": "change_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.ChangeRequestPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.PhoneChangeRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/resources/count": {
+            "get": {
+                "description": "get the total count of resources",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "resources"
+                ],
+                "summary": "Get Resource Count",
+                "responses": {
+                    "200": {
+                        "description": "Resource count",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -368,7 +1082,7 @@ const docTemplate = `{
         },
         "/resources/{id}": {
             "get": {
-                "description": "gets a single service by resource ID",
+                "description": "gets a single resource by resource ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -379,14 +1093,20 @@ const docTemplate = `{
                     "resources"
                 ],
                 "summary": "Get Resource",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Resource ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resources.Resource"
-                            }
+                            "$ref": "#/definitions/resources.ResourceResponse"
                         }
                     }
                 }
@@ -404,16 +1124,25 @@ const docTemplate = `{
                 "tags": [
                     "saved_searches"
                 ],
-                "summary": "Get Saved Search for current User",
+                "summary": "Get Saved Searches for current User",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/savedsearches.SavedSearch"
-                            }
+                            "$ref": "#/definitions/savedsearches.SavedSearches"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
                     }
                 }
             },
@@ -429,19 +1158,36 @@ const docTemplate = `{
                     "saved_searches"
                 ],
                 "summary": "Create SavedSearch for current User",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "description": "Saved search object",
+                        "name": "saved_search",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/savedsearches.SavedSearch"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/savedsearches.SavedSearch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             }
         },
         "/saved_searches/{id}": {
-            "delete": {
-                "description": "delete a saved search for user",
+            "get": {
+                "description": "get a saved search by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -451,12 +1197,101 @@ const docTemplate = `{
                 "tags": [
                     "saved_searches"
                 ],
-                "summary": "Delete saved search by ID",
+                "summary": "Get Saved Search by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Saved Search ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/savedsearches.SavedSearch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a saved search for user",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "saved_searches"
+                ],
+                "summary": "Delete saved search by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Saved Search ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/services/html_to_pdf": {
+            "post": {
+                "description": "Converts HTML to PDF, with optional translation",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "services"
+                ],
+                "summary": "Convert HTML to PDF",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "HTML content to convert",
+                        "name": "html",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target language for translation",
+                        "name": "target_language",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Generated PDF",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -475,14 +1310,55 @@ const docTemplate = `{
                     "services"
                 ],
                 "summary": "Get Service",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Service ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/services.Service"
-                            }
+                            "$ref": "#/definitions/services.ServiceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/current": {
+            "get": {
+                "description": "get the currently authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get Current User",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/users.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/users.ApiError"
                         }
                     }
                 }
@@ -531,6 +1407,43 @@ const docTemplate = `{
                 }
             }
         },
+        "bookmarks.Bookmark": {
+            "type": "object",
+            "properties": {
+                "folder_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "order": {
+                    "type": "integer"
+                },
+                "resource_id": {
+                    "type": "integer"
+                },
+                "service_id": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "bookmarks.Bookmarks": {
+            "type": "object",
+            "properties": {
+                "bookmarks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/bookmarks.Bookmark"
+                    }
+                }
+            }
+        },
         "categories.Categories": {
             "type": "object",
             "properties": {
@@ -556,6 +1469,76 @@ const docTemplate = `{
                 },
                 "top_level": {
                     "type": "boolean"
+                }
+            }
+        },
+        "categories.CategoryCountDTO": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "integer"
+                },
+                "services": {
+                    "type": "integer"
+                }
+            }
+        },
+        "changerequest.ChangeRequestPayload": {
+            "type": "object"
+        },
+        "changerequest.ChangeRequestResponse": {
+            "type": "object",
+            "properties": {
+                "field_changes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/changerequest.FieldChange"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "object_id": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "changerequest.FieldChange": {
+            "type": "object",
+            "properties": {
+                "field_name": {
+                    "type": "string"
+                },
+                "field_value": {
+                    "type": "string"
+                }
+            }
+        },
+        "changerequest.PhoneChangeRequest": {
+            "type": "object",
+            "properties": {
+                "phone_change_request": {
+                    "$ref": "#/definitions/changerequest.ChangeRequestResponse"
+                }
+            }
+        },
+        "common.Error": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
                 }
             }
         },
@@ -625,6 +1608,78 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "instruction": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticle": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticleCreateRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticleUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -760,6 +1815,14 @@ const docTemplate = `{
                 },
                 "website": {
                     "type": "string"
+                }
+            }
+        },
+        "resources.ResourceResponse": {
+            "type": "object",
+            "properties": {
+                "resource": {
+                    "$ref": "#/definitions/resources.Resource"
                 }
             }
         },
@@ -1082,27 +2145,51 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "services.ServiceResponse": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "$ref": "#/definitions/services.Service"
+                }
+            }
+        },
+        "users.ApiError": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "users.User": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization": {
+                    "type": "string"
+                }
+            }
         }
-    },
-    "securityDefinitions": {
-        "BasicAuth": {
-            "type": "basic"
-        }
-    },
-    "externalDocs": {
-        "description": "OpenAPI",
-        "url": "https://swagger.io/resources/open-api/"
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8080",
-	BasePath:         "/api/v1",
+	Host:             "localhost:3001",
+	BasePath:         "/api",
 	Schemes:          []string{},
-	Title:            "Swagger Example API",
-	Description:      "This is a sample server celler server.",
+	Title:            "ShelterTech API",
+	Description:      "API for the ShelterTech SF Service Guide application.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,23 +1,220 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "This is a sample server celler server.",
-        "title": "Swagger Example API",
-        "termsOfService": "http://swagger.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "url": "http://www.swagger.io/support",
-            "email": "support@swagger.io"
-        },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
+        "description": "API for the ShelterTech SF Service Guide application.",
+        "title": "ShelterTech API",
+        "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:8080",
-    "basePath": "/api/v1",
+    "host": "localhost:3001",
+    "basePath": "/api",
     "paths": {
+        "/bookmarks": {
+            "get": {
+                "description": "get all bookmarks, optionally filtered by user_id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Get Bookmarks",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Filter by user ID",
+                        "name": "user_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmarks"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a new bookmark",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Create Bookmark",
+                "parameters": [
+                    {
+                        "description": "Bookmark object",
+                        "name": "bookmark",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/bookmarks/{id}": {
+            "get": {
+                "description": "get a single bookmark by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Get Bookmark by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "update an existing bookmark by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Update Bookmark",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Bookmark object",
+                        "name": "bookmark",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/bookmarks.Bookmark"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a bookmark by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "bookmarks"
+                ],
+                "summary": "Delete Bookmark",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Bookmark ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "description": "get all categories",
@@ -31,14 +228,166 @@
                     "categories"
                 ],
                 "summary": "Get Categories",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter to top-level categories only",
+                        "name": "top_level",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/counts": {
+            "get": {
+                "description": "get service and resource counts for each category",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Category Counts",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/categories.Categories"
+                                "$ref": "#/definitions/categories.CategoryCountDTO"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/featured": {
+            "get": {
+                "description": "get all featured categories",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Featured Categories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/subcategories/{id}": {
+            "get": {
+                "description": "get subcategories for a given parent category ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Subcategories by Category ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Parent Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Categories"
+                        }
+                    }
+                }
+            }
+        },
+        "/categories/{id}": {
+            "get": {
+                "description": "get a single category by its ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "categories"
+                ],
+                "summary": "Get Category by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Category ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/categories.Category"
+                        }
+                    }
+                }
+            }
+        },
+        "/change_requests": {
+            "post": {
+                "description": "create a new change request (e.g. for phones)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "change_requests"
+                ],
+                "summary": "Create Change Request",
+                "parameters": [
+                    {
+                        "description": "Change request payload",
+                        "name": "change_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.ChangeRequestPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.PhoneChangeRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -47,21 +396,41 @@
         "/datathon/content_curation_dataset": {
             "get": {
                 "description": "gives a csv of the content curation dataset",
+                "produces": [
+                    "text/csv"
+                ],
                 "tags": [
                     "datathon"
                 ],
                 "summary": "Get Content Curation Dataset",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "CSV data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/datathon/datathon_dataset": {
             "get": {
                 "description": "gives a csv of the datathon dataset",
+                "produces": [
+                    "text/csv"
+                ],
                 "tags": [
                     "datathon"
                 ],
                 "summary": "Get Datathon Dataset",
-                "responses": {}
+                "responses": {
+                    "200": {
+                        "description": "CSV data",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/eligibilities": {
@@ -260,15 +629,24 @@
                     "folders"
                 ],
                 "summary": "Get Folders for current User",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/folders.Folders"
-                            }
+                            "$ref": "#/definitions/folders.Folders"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
                     }
                 }
             },
@@ -284,12 +662,29 @@
                     "folders"
                 ],
                 "summary": "Create Folder for current User",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "description": "Folder object",
+                        "name": "folder",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/folders.Folder"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             }
@@ -307,12 +702,27 @@
                     "folders"
                 ],
                 "summary": "Get folder by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
                     }
                 }
             },
@@ -328,12 +738,33 @@
                     "folders"
                 ],
                 "summary": "Update folder by ID",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Folder object",
+                        "name": "folder",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/folders.Folder"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             },
@@ -342,18 +773,301 @@
                 "consumes": [
                     "application/json"
                 ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "folders"
                 ],
                 "summary": "Delete folder by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Folder ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/news_articles": {
+            "get": {
+                "description": "Get all news articles with optional filtering for active articles only",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Get News Articles",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Filter for active news articles only",
+                        "name": "active",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/folders.Folder"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/newsarticles.NewsArticle"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new news article",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Create News Article",
+                "parameters": [
+                    {
+                        "description": "News article data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticleCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticle"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/news_articles/{id}": {
+            "put": {
+                "description": "Update an existing news article",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Update News Article",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "News Article ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "News article update data",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticleUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/newsarticles.NewsArticle"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {}
+                    },
+                    "404": {
+                        "description": "News article not found",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an existing news article",
+                "tags": [
+                    "news_articles"
+                ],
+                "summary": "Delete News Article",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "News Article ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty response on success",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid news article ID format",
+                        "schema": {}
+                    },
+                    "404": {
+                        "description": "News article not found",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/phones/{id}": {
+            "delete": {
+                "description": "delete a phone record by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "phones"
+                ],
+                "summary": "Delete Phone",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Phone ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/phones/{id}/change_requests": {
+            "post": {
+                "description": "create a change request to update phone fields",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "change_requests"
+                ],
+                "summary": "Update Phone Change Request",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Phone ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Change request payload",
+                        "name": "change_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.ChangeRequestPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/changerequest.PhoneChangeRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/resources/count": {
+            "get": {
+                "description": "get the total count of resources",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "resources"
+                ],
+                "summary": "Get Resource Count",
+                "responses": {
+                    "200": {
+                        "description": "Resource count",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -361,7 +1075,7 @@
         },
         "/resources/{id}": {
             "get": {
-                "description": "gets a single service by resource ID",
+                "description": "gets a single resource by resource ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -372,14 +1086,20 @@
                     "resources"
                 ],
                 "summary": "Get Resource",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Resource ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/resources.Resource"
-                            }
+                            "$ref": "#/definitions/resources.ResourceResponse"
                         }
                     }
                 }
@@ -397,16 +1117,25 @@
                 "tags": [
                     "saved_searches"
                 ],
-                "summary": "Get Saved Search for current User",
+                "summary": "Get Saved Searches for current User",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/savedsearches.SavedSearch"
-                            }
+                            "$ref": "#/definitions/savedsearches.SavedSearches"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request"
                     }
                 }
             },
@@ -422,19 +1151,36 @@
                     "saved_searches"
                 ],
                 "summary": "Create SavedSearch for current User",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                "parameters": [
+                    {
+                        "description": "Saved search object",
+                        "name": "saved_search",
+                        "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/savedsearches.SavedSearch"
                         }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/savedsearches.SavedSearch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
                     }
                 }
             }
         },
         "/saved_searches/{id}": {
-            "delete": {
-                "description": "delete a saved search for user",
+            "get": {
+                "description": "get a saved search by its ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -444,12 +1190,101 @@
                 "tags": [
                     "saved_searches"
                 ],
-                "summary": "Delete saved search by ID",
+                "summary": "Get Saved Search by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Saved Search ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/savedsearches.SavedSearch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
+            },
+            "delete": {
+                "description": "delete a saved search for user",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "saved_searches"
+                ],
+                "summary": "Delete saved search by ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Saved Search ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/services/html_to_pdf": {
+            "post": {
+                "description": "Converts HTML to PDF, with optional translation",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "services"
+                ],
+                "summary": "Convert HTML to PDF",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "HTML content to convert",
+                        "name": "html",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target language for translation",
+                        "name": "target_language",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Generated PDF",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
                         }
                     }
                 }
@@ -468,14 +1303,55 @@
                     "services"
                 ],
                 "summary": "Get Service",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Service ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/services.Service"
-                            }
+                            "$ref": "#/definitions/services.ServiceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/current": {
+            "get": {
+                "description": "get the currently authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get Current User",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/users.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/users.ApiError"
                         }
                     }
                 }
@@ -524,6 +1400,43 @@
                 }
             }
         },
+        "bookmarks.Bookmark": {
+            "type": "object",
+            "properties": {
+                "folder_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "order": {
+                    "type": "integer"
+                },
+                "resource_id": {
+                    "type": "integer"
+                },
+                "service_id": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "bookmarks.Bookmarks": {
+            "type": "object",
+            "properties": {
+                "bookmarks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/bookmarks.Bookmark"
+                    }
+                }
+            }
+        },
         "categories.Categories": {
             "type": "object",
             "properties": {
@@ -549,6 +1462,76 @@
                 },
                 "top_level": {
                     "type": "boolean"
+                }
+            }
+        },
+        "categories.CategoryCountDTO": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "integer"
+                },
+                "services": {
+                    "type": "integer"
+                }
+            }
+        },
+        "changerequest.ChangeRequestPayload": {
+            "type": "object"
+        },
+        "changerequest.ChangeRequestResponse": {
+            "type": "object",
+            "properties": {
+                "field_changes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/changerequest.FieldChange"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "object_id": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "changerequest.FieldChange": {
+            "type": "object",
+            "properties": {
+                "field_name": {
+                    "type": "string"
+                },
+                "field_value": {
+                    "type": "string"
+                }
+            }
+        },
+        "changerequest.PhoneChangeRequest": {
+            "type": "object",
+            "properties": {
+                "phone_change_request": {
+                    "$ref": "#/definitions/changerequest.ChangeRequestResponse"
+                }
+            }
+        },
+        "common.Error": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
                 }
             }
         },
@@ -618,6 +1601,78 @@
                     "type": "integer"
                 },
                 "instruction": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticle": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticleCreateRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "newsarticles.NewsArticleUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "effective_date": {
+                    "type": "string"
+                },
+                "expiration_date": {
+                    "type": "string"
+                },
+                "headline": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -753,6 +1808,14 @@
                 },
                 "website": {
                     "type": "string"
+                }
+            }
+        },
+        "resources.ResourceResponse": {
+            "type": "object",
+            "properties": {
+                "resource": {
+                    "$ref": "#/definitions/resources.Resource"
                 }
             }
         },
@@ -1075,15 +2138,39 @@
                     "type": "string"
                 }
             }
+        },
+        "services.ServiceResponse": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "$ref": "#/definitions/services.Service"
+                }
+            }
+        },
+        "users.ApiError": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "users.User": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization": {
+                    "type": "string"
+                }
+            }
         }
-    },
-    "securityDefinitions": {
-        "BasicAuth": {
-            "type": "basic"
-        }
-    },
-    "externalDocs": {
-        "description": "OpenAPI",
-        "url": "https://swagger.io/resources/open-api/"
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /api/v1
+basePath: /api
 definitions:
   addresses.Address:
     properties:
@@ -27,6 +27,30 @@ definitions:
       state_province:
         type: string
     type: object
+  bookmarks.Bookmark:
+    properties:
+      folder_id:
+        type: integer
+      id:
+        type: integer
+      name:
+        type: string
+      order:
+        type: integer
+      resource_id:
+        type: integer
+      service_id:
+        type: integer
+      user_id:
+        type: integer
+    type: object
+  bookmarks.Bookmarks:
+    properties:
+      bookmarks:
+        items:
+          $ref: '#/definitions/bookmarks.Bookmark'
+        type: array
+    type: object
   categories.Categories:
     properties:
       categories:
@@ -44,6 +68,51 @@ definitions:
         type: string
       top_level:
         type: boolean
+    type: object
+  categories.CategoryCountDTO:
+    properties:
+      name:
+        type: string
+      resources:
+        type: integer
+      services:
+        type: integer
+    type: object
+  changerequest.ChangeRequestPayload:
+    type: object
+  changerequest.ChangeRequestResponse:
+    properties:
+      field_changes:
+        items:
+          $ref: '#/definitions/changerequest.FieldChange'
+        type: array
+      id:
+        type: integer
+      object_id:
+        type: integer
+      status:
+        type: string
+      type:
+        type: string
+    type: object
+  changerequest.FieldChange:
+    properties:
+      field_name:
+        type: string
+      field_value:
+        type: string
+    type: object
+  changerequest.PhoneChangeRequest:
+    properties:
+      phone_change_request:
+        $ref: '#/definitions/changerequest.ChangeRequestResponse'
+    type: object
+  common.Error:
+    properties:
+      error:
+        type: string
+      status_code:
+        type: integer
     type: object
   documents.Document:
     properties:
@@ -88,6 +157,53 @@ definitions:
       id:
         type: integer
       instruction:
+        type: string
+    type: object
+  newsarticles.NewsArticle:
+    properties:
+      body:
+        type: string
+      effective_date:
+        type: string
+      expiration_date:
+        type: string
+      headline:
+        type: string
+      id:
+        type: integer
+      priority:
+        type: integer
+      url:
+        type: string
+    type: object
+  newsarticles.NewsArticleCreateRequest:
+    properties:
+      body:
+        type: string
+      effective_date:
+        type: string
+      expiration_date:
+        type: string
+      headline:
+        type: string
+      priority:
+        type: integer
+      url:
+        type: string
+    type: object
+  newsarticles.NewsArticleUpdateRequest:
+    properties:
+      body:
+        type: string
+      effective_date:
+        type: string
+      expiration_date:
+        type: string
+      headline:
+        type: string
+      priority:
+        type: integer
+      url:
         type: string
     type: object
   notes.Note:
@@ -177,6 +293,11 @@ definitions:
         type: string
       website:
         type: string
+    type: object
+  resources.ResourceResponse:
+    properties:
+      resource:
+        $ref: '#/definitions/resources.Resource'
     type: object
   resources.ResourceService:
     properties:
@@ -389,28 +510,212 @@ definitions:
       wait_time:
         type: string
     type: object
-externalDocs:
-  description: OpenAPI
-  url: https://swagger.io/resources/open-api/
-host: localhost:8080
+  services.ServiceResponse:
+    properties:
+      service:
+        $ref: '#/definitions/services.Service'
+    type: object
+  users.ApiError:
+    properties:
+      error:
+        type: string
+    type: object
+  users.User:
+    properties:
+      email:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      organization:
+        type: string
+    type: object
+host: localhost:3001
 info:
-  contact:
-    email: support@swagger.io
-    name: API Support
-    url: http://www.swagger.io/support
-  description: This is a sample server celler server.
-  license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-  termsOfService: http://swagger.io/terms/
-  title: Swagger Example API
+  contact: {}
+  description: API for the ShelterTech SF Service Guide application.
+  title: ShelterTech API
   version: "1.0"
 paths:
+  /bookmarks:
+    get:
+      consumes:
+      - application/json
+      description: get all bookmarks, optionally filtered by user_id
+      parameters:
+      - description: Filter by user ID
+        in: query
+        name: user_id
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/bookmarks.Bookmarks'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Get Bookmarks
+      tags:
+      - bookmarks
+    post:
+      consumes:
+      - application/json
+      description: create a new bookmark
+      parameters:
+      - description: Bookmark object
+        in: body
+        name: bookmark
+        required: true
+        schema:
+          $ref: '#/definitions/bookmarks.Bookmark'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Create Bookmark
+      tags:
+      - bookmarks
+  /bookmarks/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: delete a bookmark by its ID
+      parameters:
+      - description: Bookmark ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Delete Bookmark
+      tags:
+      - bookmarks
+    get:
+      consumes:
+      - application/json
+      description: get a single bookmark by its ID
+      parameters:
+      - description: Bookmark ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/bookmarks.Bookmark'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Get Bookmark by ID
+      tags:
+      - bookmarks
+    put:
+      consumes:
+      - application/json
+      description: update an existing bookmark by ID
+      parameters:
+      - description: Bookmark ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Bookmark object
+        in: body
+        name: bookmark
+        required: true
+        schema:
+          $ref: '#/definitions/bookmarks.Bookmark'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Update Bookmark
+      tags:
+      - bookmarks
   /categories:
     get:
       consumes:
       - application/json
       description: get all categories
+      parameters:
+      - description: Filter to top-level categories only
+        in: query
+        name: top_level
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/categories.Categories'
+      summary: Get Categories
+      tags:
+      - categories
+  /categories/{id}:
+    get:
+      description: get a single category by its ID
+      parameters:
+      - description: Category ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/categories.Category'
+      summary: Get Category by ID
+      tags:
+      - categories
+  /categories/counts:
+    get:
+      description: get service and resource counts for each category
       produces:
       - application/json
       responses:
@@ -418,22 +723,96 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/categories.Categories'
+              $ref: '#/definitions/categories.CategoryCountDTO'
             type: array
-      summary: Get Categories
+      summary: Get Category Counts
       tags:
       - categories
+  /categories/featured:
+    get:
+      description: get all featured categories
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/categories.Categories'
+      summary: Get Featured Categories
+      tags:
+      - categories
+  /categories/subcategories/{id}:
+    get:
+      description: get subcategories for a given parent category ID
+      parameters:
+      - description: Parent Category ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/categories.Categories'
+      summary: Get Subcategories by Category ID
+      tags:
+      - categories
+  /change_requests:
+    post:
+      consumes:
+      - application/json
+      description: create a new change request (e.g. for phones)
+      parameters:
+      - description: Change request payload
+        in: body
+        name: change_request
+        required: true
+        schema:
+          $ref: '#/definitions/changerequest.ChangeRequestPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/changerequest.PhoneChangeRequest'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Create Change Request
+      tags:
+      - change_requests
   /datathon/content_curation_dataset:
     get:
       description: gives a csv of the content curation dataset
-      responses: {}
+      produces:
+      - text/csv
+      responses:
+        "200":
+          description: CSV data
+          schema:
+            type: string
       summary: Get Content Curation Dataset
       tags:
       - datathon
   /datathon/datathon_dataset:
     get:
       description: gives a csv of the datathon dataset
-      responses: {}
+      produces:
+      - text/csv
+      responses:
+        "200":
+          description: CSV data
+          schema:
+            type: string
       summary: Get Datathon Dataset
       tags:
       - datathon
@@ -567,15 +946,21 @@ paths:
       consumes:
       - application/json
       description: get folders for user
+      parameters:
+      - description: User ID
+        in: query
+        name: user_id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/folders.Folders'
-            type: array
+            $ref: '#/definitions/folders.Folders'
+        "400":
+          description: Bad Request
       summary: Get Folders for current User
       tags:
       - folders
@@ -583,13 +968,24 @@ paths:
       consumes:
       - application/json
       description: new folder for user
+      parameters:
+      - description: Folder object
+        in: body
+        name: folder
+        required: true
+        schema:
+          $ref: '#/definitions/folders.Folder'
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           schema:
             $ref: '#/definitions/folders.Folder'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
       summary: Create Folder for current User
       tags:
       - folders
@@ -598,13 +994,19 @@ paths:
       consumes:
       - application/json
       description: delete a folder for user
-      produces:
-      - application/json
+      parameters:
+      - description: Folder ID
+        in: path
+        name: id
+        required: true
+        type: integer
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/folders.Folder'
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
       summary: Delete folder by ID
       tags:
       - folders
@@ -612,6 +1014,12 @@ paths:
       consumes:
       - application/json
       description: get current folder for user
+      parameters:
+      - description: Folder ID
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
@@ -619,6 +1027,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/folders.Folder'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
       summary: Get folder by ID
       tags:
       - folders
@@ -626,21 +1038,39 @@ paths:
       consumes:
       - application/json
       description: update a folder for user
+      parameters:
+      - description: Folder ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Folder object
+        in: body
+        name: folder
+        required: true
+        schema:
+          $ref: '#/definitions/folders.Folder'
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/folders.Folder'
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
       summary: Update folder by ID
       tags:
       - folders
-  /resources/{id}:
+  /news_articles:
     get:
-      consumes:
-      - application/json
-      description: gets a single service by resource ID
+      description: Get all news articles with optional filtering for active articles
+        only
+      parameters:
+      - description: Filter for active news articles only
+        in: query
+        name: active
+        type: boolean
       produces:
       - application/json
       responses:
@@ -648,9 +1078,193 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/resources.Resource'
+              $ref: '#/definitions/newsarticles.NewsArticle'
             type: array
+      summary: Get News Articles
+      tags:
+      - news_articles
+    post:
+      consumes:
+      - application/json
+      description: Create a new news article
+      parameters:
+      - description: News article data
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/newsarticles.NewsArticleCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/newsarticles.NewsArticle'
+        "400":
+          description: Invalid request body
+          schema: {}
+        "500":
+          description: Internal server error
+          schema: {}
+      summary: Create News Article
+      tags:
+      - news_articles
+  /news_articles/{id}:
+    delete:
+      description: Delete an existing news article
+      parameters:
+      - description: News Article ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: Empty response on success
+          schema:
+            type: object
+        "400":
+          description: Invalid news article ID format
+          schema: {}
+        "404":
+          description: News article not found
+          schema: {}
+        "500":
+          description: Internal server error
+          schema: {}
+      summary: Delete News Article
+      tags:
+      - news_articles
+    put:
+      consumes:
+      - application/json
+      description: Update an existing news article
+      parameters:
+      - description: News Article ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: News article update data
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/newsarticles.NewsArticleUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/newsarticles.NewsArticle'
+        "400":
+          description: Invalid request body
+          schema: {}
+        "404":
+          description: News article not found
+          schema: {}
+        "500":
+          description: Internal server error
+          schema: {}
+      summary: Update News Article
+      tags:
+      - news_articles
+  /phones/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: delete a phone record by its ID
+      parameters:
+      - description: Phone ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Delete Phone
+      tags:
+      - phones
+  /phones/{id}/change_requests:
+    post:
+      consumes:
+      - application/json
+      description: create a change request to update phone fields
+      parameters:
+      - description: Phone ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Change request payload
+        in: body
+        name: change_request
+        required: true
+        schema:
+          $ref: '#/definitions/changerequest.ChangeRequestPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/changerequest.PhoneChangeRequest'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Update Phone Change Request
+      tags:
+      - change_requests
+  /resources/{id}:
+    get:
+      consumes:
+      - application/json
+      description: gets a single resource by resource ID
+      parameters:
+      - description: Resource ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/resources.ResourceResponse'
       summary: Get Resource
+      tags:
+      - resources
+  /resources/count:
+    get:
+      description: get the total count of resources
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: Resource count
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Get Resource Count
       tags:
       - resources
   /saved_searches:
@@ -658,29 +1272,46 @@ paths:
       consumes:
       - application/json
       description: get saved searches for user
+      parameters:
+      - description: User ID
+        in: query
+        name: user_id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/savedsearches.SavedSearch'
-            type: array
-      summary: Get Saved Search for current User
+            $ref: '#/definitions/savedsearches.SavedSearches'
+        "400":
+          description: Bad Request
+      summary: Get Saved Searches for current User
       tags:
       - saved_searches
     post:
       consumes:
       - application/json
       description: new saved search for user
+      parameters:
+      - description: Saved search object
+        in: body
+        name: saved_search
+        required: true
+        schema:
+          $ref: '#/definitions/savedsearches.SavedSearch'
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           schema:
             $ref: '#/definitions/savedsearches.SavedSearch'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
       summary: Create SavedSearch for current User
       tags:
       - saved_searches
@@ -689,6 +1320,30 @@ paths:
       consumes:
       - application/json
       description: delete a saved search for user
+      parameters:
+      - description: Saved Search ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+        "500":
+          description: Internal Server Error
+      summary: Delete saved search by ID
+      tags:
+      - saved_searches
+    get:
+      consumes:
+      - application/json
+      description: get a saved search by its ID
+      parameters:
+      - description: Saved Search ID
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
@@ -696,7 +1351,9 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/savedsearches.SavedSearch'
-      summary: Delete saved search by ID
+        "400":
+          description: Bad Request
+      summary: Get Saved Search by ID
       tags:
       - saved_searches
   /services/{id}:
@@ -704,19 +1361,76 @@ paths:
       consumes:
       - application/json
       description: gets a single service by service ID
+      parameters:
+      - description: Service ID
+        in: path
+        name: id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/services.Service'
-            type: array
+            $ref: '#/definitions/services.ServiceResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
       summary: Get Service
       tags:
       - services
-securityDefinitions:
-  BasicAuth:
-    type: basic
+  /services/html_to_pdf:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Converts HTML to PDF, with optional translation
+      parameters:
+      - description: HTML content to convert
+        in: formData
+        name: html
+        required: true
+        type: string
+      - description: Target language for translation
+        in: formData
+        name: target_language
+        type: string
+      produces:
+      - application/pdf
+      responses:
+        "200":
+          description: Generated PDF
+          schema:
+            type: file
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.Error'
+      summary: Convert HTML to PDF
+      tags:
+      - services
+  /users/current:
+    get:
+      consumes:
+      - application/json
+      description: get the currently authenticated user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/users.User'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/users.ApiError'
+      summary: Get Current User
+      tags:
+      - users
 swagger: "2.0"

--- a/internal/bookmarks/manager.go
+++ b/internal/bookmarks/manager.go
@@ -24,6 +24,18 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
+// Get lists all bookmarks, optionally filtered by user_id
+//
+//	@Summary		Get Bookmarks
+//	@Description	get all bookmarks, optionally filtered by user_id
+//	@Tags			bookmarks
+//	@Accept			json
+//	@Produce		json
+//	@Param			user_id	query		int	false	"Filter by user ID"
+//	@Success		200		{object}	bookmarks.Bookmarks
+//	@Failure		400		{object}	common.Error
+//	@Failure		500		{object}	common.Error
+//	@Router			/bookmarks [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 
 	var dbBookmarks []*db.Bookmark
@@ -58,6 +70,18 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, response)
 }
 
+// GetByID gets a bookmark by ID
+//
+//	@Summary		Get Bookmark by ID
+//	@Description	get a single bookmark by its ID
+//	@Tags			bookmarks
+//	@Accept			json
+//	@Produce		json
+//	@Param			id	path		int	true	"Bookmark ID"
+//	@Success		200	{object}	bookmarks.Bookmark
+//	@Failure		400	{object}	common.Error
+//	@Failure		500	{object}	common.Error
+//	@Router			/bookmarks/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
@@ -79,6 +103,18 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, response)
 }
 
+// Submit creates a new bookmark
+//
+//	@Summary		Create Bookmark
+//	@Description	create a new bookmark
+//	@Tags			bookmarks
+//	@Accept			json
+//	@Produce		json
+//	@Param			bookmark	body	bookmarks.Bookmark	true	"Bookmark object"
+//	@Success		201
+//	@Failure		400	{object}	common.Error
+//	@Failure		500	{object}	common.Error
+//	@Router			/bookmarks [post]
 func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
@@ -111,6 +147,19 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 	writeStatus(w, http.StatusCreated)
 }
 
+// Update updates an existing bookmark
+//
+//	@Summary		Update Bookmark
+//	@Description	update an existing bookmark by ID
+//	@Tags			bookmarks
+//	@Accept			json
+//	@Produce		json
+//	@Param			id			path	int					true	"Bookmark ID"
+//	@Param			bookmark	body	bookmarks.Bookmark	true	"Bookmark object"
+//	@Success		201
+//	@Failure		400	{object}	common.Error
+//	@Failure		500	{object}	common.Error
+//	@Router			/bookmarks/{id} [put]
 func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
@@ -145,6 +194,16 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// DeleteByID deletes a bookmark by ID
+//
+//	@Summary		Delete Bookmark
+//	@Description	delete a bookmark by its ID
+//	@Tags			bookmarks
+//	@Accept			json
+//	@Param			id	path		int	true	"Bookmark ID"
+//	@Success		204
+//	@Failure		400	{object}	common.Error
+//	@Router			/bookmarks/{id} [delete]
 func (m *Manager) DeleteByID(w http.ResponseWriter, r *http.Request) {
 
 	bookmarkId, err := strconv.Atoi(chi.URLParam(r, "id"))

--- a/internal/categories/manager.go
+++ b/internal/categories/manager.go
@@ -31,7 +31,8 @@ func New(dbManager *db.Manager) *Manager {
 //	@Tags			categories
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	categories.Categories
+//	@Param			top_level	query		bool	false	"Filter to top-level categories only"
+//	@Success		200			{object}	categories.Categories
 //	@Router			/categories [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	topLevelString := r.URL.Query().Get("top_level")
@@ -50,6 +51,14 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, response)
 }
 
+// GetCategoryCounts returns service and resource counts per category
+//
+//	@Summary		Get Category Counts
+//	@Description	get service and resource counts for each category
+//	@Tags			categories
+//	@Produce		json
+//	@Success		200	{array}	categories.CategoryCountDTO
+//	@Router			/categories/counts [get]
 func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
 	// Get all categories first
 	allCategories := m.DbClient.GetCategories(nil)
@@ -98,6 +107,15 @@ func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
 	writeJson(w, response)
 }
 
+// GetByID gets a category by ID
+//
+//	@Summary		Get Category by ID
+//	@Description	get a single category by its ID
+//	@Tags			categories
+//	@Produce		json
+//	@Param			id	path		int	true	"Category ID"
+//	@Success		200	{object}	categories.Category
+//	@Router			/categories/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	categoryId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
@@ -107,6 +125,15 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, FromDBType(dbCategory))
 }
 
+// GetSubCategoriesByID gets subcategories of a category
+//
+//	@Summary		Get Subcategories by Category ID
+//	@Description	get subcategories for a given parent category ID
+//	@Tags			categories
+//	@Produce		json
+//	@Param			id	path		int	true	"Parent Category ID"
+//	@Success		200	{object}	categories.Categories
+//	@Router			/categories/subcategories/{id} [get]
 func (m *Manager) GetSubCategoriesByID(w http.ResponseWriter, r *http.Request) {
 	categoryId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
@@ -119,6 +146,14 @@ func (m *Manager) GetSubCategoriesByID(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, response)
 }
 
+// GetByFeatured gets featured categories
+//
+//	@Summary		Get Featured Categories
+//	@Description	get all featured categories
+//	@Tags			categories
+//	@Produce		json
+//	@Success		200	{object}	categories.Categories
+//	@Router			/categories/featured [get]
 func (m *Manager) GetByFeatured(w http.ResponseWriter, _ *http.Request) {
 	dbCategories := m.DbClient.GetCategoriesByFeatured()
 	response := Categories{

--- a/internal/changerequest/manager.go
+++ b/internal/changerequest/manager.go
@@ -25,6 +25,18 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
+// Create creates a new change request
+//
+//	@Summary		Create Change Request
+//	@Description	create a new change request (e.g. for phones)
+//	@Tags			change_requests
+//	@Accept			json
+//	@Produce		json
+//	@Param			change_request	body		changerequest.ChangeRequestPayload	true	"Change request payload"
+//	@Success		201				{object}	changerequest.PhoneChangeRequest
+//	@Failure		400				{object}	common.Error
+//	@Failure		500				{object}	common.Error
+//	@Router			/change_requests [post]
 func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	changeRequestPayload := unmarshalPayload(w, r)
@@ -35,6 +47,19 @@ func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// UpdatePhone updates a phone via a change request
+//
+//	@Summary		Update Phone Change Request
+//	@Description	create a change request to update phone fields
+//	@Tags			change_requests
+//	@Accept			json
+//	@Produce		json
+//	@Param			id				path		int									true	"Phone ID"
+//	@Param			change_request	body		changerequest.ChangeRequestPayload	true	"Change request payload"
+//	@Success		201				{object}	changerequest.PhoneChangeRequest
+//	@Failure		400				{object}	common.Error
+//	@Failure		500				{object}	common.Error
+//	@Router			/phones/{id}/change_requests [post]
 func (m *Manager) UpdatePhone(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	changeRequestPayload := unmarshalPayload(w, r)

--- a/internal/datathon/manager.go
+++ b/internal/datathon/manager.go
@@ -23,6 +23,8 @@ func New(dbManager *db.Manager) *Manager {
 //	@Summary		Get Content Curation Dataset
 //	@Description	gives a csv of the content curation dataset
 //	@Tags			datathon
+//	@Produce		text/csv
+//	@Success		200	{string}	string	"CSV data"
 //	@Router			/datathon/content_curation_dataset [get]
 func (m *Manager) GetContentCurationDataset(w http.ResponseWriter, r *http.Request) {
 	dbContentCurationData := m.DbClient.GetContentCurationData()
@@ -34,6 +36,8 @@ func (m *Manager) GetContentCurationDataset(w http.ResponseWriter, r *http.Reque
 //	@Summary		Get Datathon Dataset
 //	@Description	gives a csv of the datathon dataset
 //	@Tags			datathon
+//	@Produce		text/csv
+//	@Success		200	{string}	string	"CSV data"
 //	@Router			/datathon/datathon_dataset [get]
 func (m *Manager) GetDatathonDataset(w http.ResponseWriter, r *http.Request) {
 	dbContentCurationData := m.DbClient.GetDatathonData()

--- a/internal/folders/manager.go
+++ b/internal/folders/manager.go
@@ -31,7 +31,9 @@ func New(dbManager *db.Manager) *Manager {
 //	@Tags			folders
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	folders.Folders
+//	@Param			user_id	query		int	true	"User ID"
+//	@Success		200		{object}	folders.Folders
+//	@Failure		400
 //	@Router			/folders [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	userId, err := strconv.Atoi(r.URL.Query().Get("user_id"))
@@ -56,7 +58,10 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 //	@Tags			folders
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	folders.Folder
+//	@Param			folder	body		folders.Folder	true	"Folder object"
+//	@Success		201		{object}	folders.Folder
+//	@Failure		400
+//	@Failure		500
 //	@Router			/folders [post]
 func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
@@ -100,7 +105,10 @@ func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 //	@Tags			folders
 //	@Accept			json
 //	@Produce		json
+//	@Param			id	path		int	true	"Folder ID"
 //	@Success		200	{object}	folders.Folder
+//	@Failure		400
+//	@Failure		404
 //	@Router			/folders/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	folderId, err := strconv.Atoi(chi.URLParam(r, "id"))
@@ -128,7 +136,11 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 //	@Tags			folders
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	folders.Folder
+//	@Param			id		path	int				true	"Folder ID"
+//	@Param			folder	body	folders.Folder	true	"Folder object"
+//	@Success		201
+//	@Failure		400
+//	@Failure		500
 //	@Router			/folders/{id} [put]
 func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
@@ -163,8 +175,10 @@ func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 //	@Description	delete a folder for user
 //	@Tags			folders
 //	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	folders.Folder
+//	@Param			id	path	int	true	"Folder ID"
+//	@Success		204
+//	@Failure		400
+//	@Failure		500
 //	@Router			/folders/{id} [delete]
 func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 	folderId, err := strconv.Atoi(chi.URLParam(r, "id"))

--- a/internal/phones/manager.go
+++ b/internal/phones/manager.go
@@ -22,13 +22,16 @@ func New(dbManager *db.Manager) *Manager {
 
 // Deletes a phones table row given its id
 //
-//	@Summary		Delete Phones
-//	@Description	delete a phones row given its id
+//	@Summary		Delete Phone
+//	@Description	delete a phone record by its ID
 //	@Tags			phones
 //	@Accept			json
-//	@Produce		None
-//	@Success		204 No Content
-//	@Router			/phones [delete]
+//	@Param			id	path	int	true	"Phone ID"
+//	@Success		204
+//	@Failure		400
+//	@Failure		404
+//	@Failure		500
+//	@Router			/phones/{id} [delete]
 func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.Atoi(idStr)

--- a/internal/resources/manager.go
+++ b/internal/resources/manager.go
@@ -30,11 +30,12 @@ func New(dbManager *db.Manager) *Manager {
 // GetByID Get a resource by ID
 //
 //	@Summary		Get Resource
-//	@Description	gets a single service by resource ID
+//	@Description	gets a single resource by resource ID
 //	@Tags			resources
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	resources.Resource
+//	@Param			id	path		int	true	"Resource ID"
+//	@Success		200	{object}	resources.ResourceResponse
 //	@Router			/resources/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	resourceId, err := strconv.Atoi(chi.URLParam(r, "id"))
@@ -56,6 +57,15 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, resourceResponse)
 }
 
+// GetCount returns the total number of resources
+//
+//	@Summary		Get Resource Count
+//	@Description	get the total count of resources
+//	@Tags			resources
+//	@Produce		plain
+//	@Success		200	{string}	string	"Resource count"
+//	@Failure		500	{object}	common.Error
+//	@Router			/resources/count [get]
 func (m *Manager) GetCount(w http.ResponseWriter, r *http.Request) {
 	count, err := m.DbClient.GetResourcesCount()
 	if err != nil {

--- a/internal/savedsearches/manager.go
+++ b/internal/savedsearches/manager.go
@@ -33,7 +33,9 @@ func New(dbManager *db.Manager) *Manager {
 //	@Tags			saved_searches
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	savedsearches.SavedSearches
+//	@Param			user_id	query		int	true	"User ID"
+//	@Success		200		{object}	savedsearches.SavedSearches
+//	@Failure		400
 //	@Router			/saved_searches [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	userId, err := strconv.Atoi(r.URL.Query().Get("user_id"))
@@ -70,7 +72,10 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 //	@Tags			saved_searches
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	savedsearches.SavedSearch
+//	@Param			saved_search	body		savedsearches.SavedSearch	true	"Saved search object"
+//	@Success		201				{object}	savedsearches.SavedSearch
+//	@Failure		400
+//	@Failure		500
 //	@Router			/saved_searches [post]
 func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
@@ -167,13 +172,15 @@ func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 // Get saved searches for current user
 // (note - I don't have the user auth stuff here)
 //
-//	@Summary		Get Saved Search for current User
-//	@Description	get saved searches for user
+//	@Summary		Get Saved Search by ID
+//	@Description	get a saved search by its ID
 //	@Tags			saved_searches
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	savedsearches.SavedSearch
-//	@Router			/saved_searches [get]
+//	@Param			id	path		int	true	"Saved Search ID"
+//	@Success		200	{object}	savedsearches.SavedSearch
+//	@Failure		400
+//	@Router			/saved_searches/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	savedSearchId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
@@ -210,8 +217,9 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 //	@Description	delete a saved search for user
 //	@Tags			saved_searches
 //	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	savedsearches.SavedSearch
+//	@Param			id	path	int	true	"Saved Search ID"
+//	@Success		200
+//	@Failure		500
 //	@Router			/saved_searches/{id} [delete]
 func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -74,7 +74,9 @@ func NewWithDependencies(
 //	@Tags			services
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{array}	services.Service
+//	@Param			id	path		int	true	"Service ID"
+//	@Success		200	{object}	services.ServiceResponse
+//	@Failure		400	{object}	common.Error
 //	@Router			/services/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	// Get the ID from the URL parameters
@@ -138,7 +140,9 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 //	@Param			html			formData	string	true	"HTML content to convert"
 //	@Param			target_language	formData	string	false	"Target language for translation"
 //	@Success		200	{file}	file	"Generated PDF"
-//	@Router			/convert-html-to-pdf [post]
+//	@Failure		400	{object}	common.Error
+//	@Failure		500	{object}	common.Error
+//	@Router			/services/html_to_pdf [post]
 func (m *Manager) ConvertHtmlToPdf(w http.ResponseWriter, r *http.Request) {
 	// Parse form data
 	if err := r.ParseForm(); err != nil {

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -23,7 +23,16 @@ func New(dbManager *db.Manager, jwtKeyfunc keyfunc.Keyfunc) *Manager {
 	return manager
 }
 
-// Get the currently authenticated user
+// GetCurrent gets the currently authenticated user
+//
+//	@Summary		Get Current User
+//	@Description	get the currently authenticated user
+//	@Tags			users
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	users.User
+//	@Failure		400	{object}	users.ApiError
+//	@Router			/users/current [get]
 func (m *Manager) GetCurrent(w http.ResponseWriter, r *http.Request) {
 	dbUser, err := auth.GetUserFromRequest(r, m.JwtKeyfunc, m.DbClient)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Fixed main.go metadata**: replaced placeholder Petstore/example values with actual ShelterTech API title, description, host (`localhost:3001`), and basepath (`/api`)
- **Added missing swagger annotations**: bookmarks (5 handlers), changerequest (Create + UpdatePhone), and users (GetCurrent) had zero swagger annotations
- **Fixed existing annotations**: corrected `@Router` paths (phones, savedsearches GetByID, services html_to_pdf), added `@Param` tags for path/query params, added `@Failure` tags, and fixed `@Success` status codes (201 for creates, 204 for deletes)
- **Regenerated docs/**: `swagger.yaml`, `swagger.json`, and `docs.go` now cover all 26 API paths

## Test plan
- [x] `swag init -g cmd/sheltertech-go/main.go` runs without errors
- [x] `docs/swagger.yaml` contains all 26 endpoint paths
- [x] `go build ./...` compiles successfully
- [ ] Visit `/api/swagger/index.html` locally to verify the Swagger UI renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)