### PR TITLE
The resources change Request handler Migration

### DIFF
--- a/cmd/sheltertech-go/main.go
+++ b/cmd/sheltertech-go/main.go
@@ -135,6 +135,7 @@ func main() {
 
 		r.Delete("/api/phones/{id}", phonesManager.Delete)
 		r.Post("/api/phones/{id}/change_requests", changeRequestManager.UpdatePhone)
+		r.Post("/api/resources/{id}/change_requests", changeRequestManager.UpdateResource)
 
 		r.Post("/api/change_requests", changeRequestManager.Create)
 	})

--- a/cmd/sheltertech-go/resources_integration_test.go
+++ b/cmd/sheltertech-go/resources_integration_test.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -34,4 +37,127 @@ func TestGetResourcesCount(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Greaterf(t, byteToInt, 1, "Count is a match")
+}
+
+func TestCreateResourceChangeRequestSingleField(t *testing.T) {
+	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
+
+	payload := map[string]interface{}{
+		"change_request": map[string]string{
+			"internal_note": "integration test note",
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+	var response map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&response)
+	require.NoError(t, err)
+
+	cr := response["resource_change_request"].(map[string]interface{})
+	assert.Equal(t, "pending", cr["status"])
+	assert.Equal(t, "ResourceChangeRequest", cr["type"])
+	assert.Equal(t, float64(1), cr["object_id"])
+
+	fieldChanges := cr["field_changes"].([]interface{})
+	assert.Len(t, fieldChanges, 1)
+	fc := fieldChanges[0].(map[string]interface{})
+	assert.Equal(t, "internal_note", fc["field_name"])
+	assert.Equal(t, "integration test note", fc["field_value"])
+}
+
+func TestCreateResourceChangeRequestEmptyBody(t *testing.T) {
+	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
+
+	payload := map[string]interface{}{
+		"change_request": map[string]string{},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+	var response map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&response)
+	require.NoError(t, err)
+
+	cr := response["resource_change_request"].(map[string]interface{})
+	assert.Equal(t, "pending", cr["status"])
+
+	fieldChanges := cr["field_changes"].([]interface{})
+	assert.Len(t, fieldChanges, 0)
+}
+
+func TestCreateResourceChangeRequestInvalidID(t *testing.T) {
+	url := fmt.Sprintf("%s/abc/change_requests", resourceUrl)
+
+	payload := map[string]interface{}{
+		"change_request": map[string]string{
+			"name": "test",
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+}
+
+func TestCreateResourceChangeRequestMultipleFields(t *testing.T) {
+	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
+
+	payload := map[string]interface{}{
+		"change_request": map[string]string{
+			"name":         "Updated Name",
+			"email":        "updated@example.com",
+			"legal_status": "Non-profit",
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+	var response map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&response)
+	require.NoError(t, err)
+
+	cr := response["resource_change_request"].(map[string]interface{})
+	fieldChanges := cr["field_changes"].([]interface{})
+	assert.Len(t, fieldChanges, 3)
+
+	fieldNames := make([]string, 0, 3)
+	for _, fc := range fieldChanges {
+		fieldNames = append(fieldNames, fc.(map[string]interface{})["field_name"].(string))
+	}
+	assert.ElementsMatch(t, []string{"name", "email", "legal_status"}, fieldNames)
 }

--- a/cmd/sheltertech-go/resources_integration_test.go
+++ b/cmd/sheltertech-go/resources_integration_test.go
@@ -43,8 +43,11 @@ func TestCreateResourceChangeRequestSingleField(t *testing.T) {
 	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
 
 	payload := map[string]interface{}{
-		"change_request": map[string]string{
-			"internal_note": "integration test note",
+		"change_request": map[string]interface{}{
+			"field_changes": map[string]string{
+				"internal_note": "integration test note",
+			},
+			"action": "edit",
 		},
 	}
 	body, err := json.Marshal(payload)
@@ -79,7 +82,10 @@ func TestCreateResourceChangeRequestEmptyBody(t *testing.T) {
 	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
 
 	payload := map[string]interface{}{
-		"change_request": map[string]string{},
+		"change_request": map[string]interface{}{
+			"field_changes": map[string]string{},
+			"action":        "edit",
+		},
 	}
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)
@@ -108,8 +114,11 @@ func TestCreateResourceChangeRequestInvalidID(t *testing.T) {
 	url := fmt.Sprintf("%s/abc/change_requests", resourceUrl)
 
 	payload := map[string]interface{}{
-		"change_request": map[string]string{
-			"name": "test",
+		"change_request": map[string]interface{}{
+			"field_changes": map[string]string{
+				"name": "test",
+			},
+			"action": "edit",
 		},
 	}
 	body, err := json.Marshal(payload)
@@ -129,10 +138,13 @@ func TestCreateResourceChangeRequestMultipleFields(t *testing.T) {
 	url := fmt.Sprintf("%s/%d/change_requests", resourceUrl, 1)
 
 	payload := map[string]interface{}{
-		"change_request": map[string]string{
-			"name":         "Updated Name",
-			"email":        "updated@example.com",
-			"legal_status": "Non-profit",
+		"change_request": map[string]interface{}{
+			"field_changes": map[string]string{
+				"name":         "Updated Name",
+				"email":        "updated@example.com",
+				"legal_status": "Non-profit",
+			},
+			"action": "edit",
 		},
 	}
 	body, err := json.Marshal(payload)

--- a/internal/changerequest/manager.go
+++ b/internal/changerequest/manager.go
@@ -38,13 +38,7 @@ func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 func (m *Manager) UpdateResource(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	body, _ := io.ReadAll(r.Body)
-	payload := &ResourceChangeRequestPayload{}
-	err := json.Unmarshal(body, payload)
-	if err != nil {
-		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	payload := unmarshalPayload(w, r)
 
 	idStr := chi.URLParam(r, "id")
 	resourceId, err := strconv.Atoi(idStr)
@@ -54,7 +48,7 @@ func (m *Manager) UpdateResource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resourceFields := &ResourceFields{}
-	err = json.Unmarshal(payload.ChangeRequest, resourceFields)
+	err = json.Unmarshal(payload.ChangeRequest.FieldChanges, resourceFields)
 	if err != nil {
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/changerequest/manager.go
+++ b/internal/changerequest/manager.go
@@ -35,6 +35,88 @@ func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (m *Manager) UpdateResource(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	body, _ := io.ReadAll(r.Body)
+	payload := &ResourceChangeRequestPayload{}
+	err := json.Unmarshal(body, payload)
+	if err != nil {
+		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	idStr := chi.URLParam(r, "id")
+	resourceId, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "Invalid resource ID", http.StatusBadRequest)
+		return
+	}
+
+	resourceFields := &ResourceFields{}
+	err = json.Unmarshal(payload.ChangeRequest, resourceFields)
+	if err != nil {
+		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	fieldChangesMap := make(map[string]interface{})
+	fieldChangesResponse := []FieldChange{}
+
+	if resourceFields.Name != nil {
+		fieldChangesMap["name"] = *resourceFields.Name
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "name", FieldValue: *resourceFields.Name})
+	}
+	if resourceFields.AlternateName != nil {
+		fieldChangesMap["alternate_name"] = *resourceFields.AlternateName
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "alternate_name", FieldValue: *resourceFields.AlternateName})
+	}
+	if resourceFields.ShortDescription != nil {
+		fieldChangesMap["short_description"] = *resourceFields.ShortDescription
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "short_description", FieldValue: *resourceFields.ShortDescription})
+	}
+	if resourceFields.LongDescription != nil {
+		fieldChangesMap["long_description"] = *resourceFields.LongDescription
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "long_description", FieldValue: *resourceFields.LongDescription})
+	}
+	if resourceFields.Website != nil {
+		fieldChangesMap["website"] = *resourceFields.Website
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "website", FieldValue: *resourceFields.Website})
+	}
+	if resourceFields.Email != nil {
+		fieldChangesMap["email"] = *resourceFields.Email
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "email", FieldValue: *resourceFields.Email})
+	}
+	if resourceFields.LegalStatus != nil {
+		fieldChangesMap["legal_status"] = *resourceFields.LegalStatus
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "legal_status", FieldValue: *resourceFields.LegalStatus})
+	}
+	if resourceFields.InternalNote != nil {
+		fieldChangesMap["internal_note"] = *resourceFields.InternalNote
+		fieldChangesResponse = append(fieldChangesResponse, FieldChange{FieldName: "internal_note", FieldValue: *resourceFields.InternalNote})
+	}
+
+	changeRequestId, err := m.DbClient.UpdateResource(resourceId, fieldChangesMap)
+	if err != nil {
+		common.WriteErrorJson(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	response := &ResourceChangeRequest{
+		ResourceChangeRequest: ChangeRequestResponse{
+			Id:           *changeRequestId,
+			Status:       "pending",
+			Type:         "ResourceChangeRequest",
+			ObjectID:     resourceId,
+			FieldChanges: fieldChangesResponse,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeStatus(w, http.StatusCreated)
+	writeJson(w, response)
+}
+
 func (m *Manager) UpdatePhone(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	changeRequestPayload := unmarshalPayload(w, r)

--- a/internal/changerequest/types.go
+++ b/internal/changerequest/types.go
@@ -33,3 +33,22 @@ type PhoneFields struct {
 	Number      *string `json:"number,omitempty"`
 	ServiceType *string `json:"service_type,omitempty"`
 }
+
+type ResourceChangeRequestPayload struct {
+	ChangeRequest json.RawMessage `json:"change_request"`
+}
+
+type ResourceFields struct {
+	Name             *string `json:"name,omitempty"`
+	AlternateName    *string `json:"alternate_name,omitempty"`
+	ShortDescription *string `json:"short_description,omitempty"`
+	LongDescription  *string `json:"long_description,omitempty"`
+	Website          *string `json:"website,omitempty"`
+	Email            *string `json:"email,omitempty"`
+	LegalStatus      *string `json:"legal_status,omitempty"`
+	InternalNote     *string `json:"internal_note,omitempty"`
+}
+
+type ResourceChangeRequest struct {
+	ResourceChangeRequest ChangeRequestResponse `json:"resource_change_request"`
+}

--- a/internal/changerequest/types.go
+++ b/internal/changerequest/types.go
@@ -34,10 +34,6 @@ type PhoneFields struct {
 	ServiceType *string `json:"service_type,omitempty"`
 }
 
-type ResourceChangeRequestPayload struct {
-	ChangeRequest json.RawMessage `json:"change_request"`
-}
-
 type ResourceFields struct {
 	Name             *string `json:"name,omitempty"`
 	AlternateName    *string `json:"alternate_name,omitempty"`

--- a/internal/db/resources.go
+++ b/internal/db/resources.go
@@ -56,6 +56,62 @@ func (m *Manager) GetResourcesCount() (int, error) {
 
 }
 
+func (m *Manager) UpdateResource(
+	resourceId int,
+	fieldChanges map[string]interface{},
+) (*int, error) {
+	tx, err := m.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Only update the resources row if there are field changes
+	if len(fieldChanges) != 0 {
+		allowed := []string{"name", "alternate_name", "short_description", "long_description", "website", "email", "legal_status", "internal_note"}
+		updateResourceSql, args := buildUpdateQuery(
+			"resources",
+			"id",
+			resourceId,
+			fieldChanges,
+			allowed,
+		)
+		_, err = tx.Exec(updateResourceSql, args...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// change_requests row is inserted even if there are no field changes
+	var changeRequestId int
+	err = tx.QueryRow(
+		insertChangeRequestSql,
+		"ResourceChangeRequest",
+		resourceId,
+		StatusPending,
+		ActionEdit,
+		resourceId,
+	).Scan(&changeRequestId)
+	if err != nil {
+		return nil, err
+	}
+
+	// insert field_changes row for each field change
+	for key, value := range fieldChanges {
+		_, err = tx.Exec(insertFieldChangeSql, key, value, changeRequestId)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return &changeRequestId, nil
+}
+
 func scanResource(row *sql.Row) *Resource {
 	var resource Resource
 	err := row.Scan(&resource.Id, &resource.Name, &resource.ShortDescription, &resource.LongDescription, &resource.Website, &resource.VerifiedAt, &resource.Email, &resource.Status, &resource.Certified, &resource.AlternateName, &resource.LegalStatus, &resource.ContactId, &resource.FundingId, &resource.CertifiedAt, &resource.Featured, &resource.SourceAttribution, &resource.InternalNote, &resource.UpdatedAt)


### PR DESCRIPTION
## Summary

- Adds `POST /api/resources/{id}/change_requests` to the Go service, migrated from the Ruby `ResourceChangeRequest` handler
- Applies field changes immediately in a DB transaction (same approach as the existing phone change request handler)
- Stores a `pending` change request record and field-level audit entries in `change_requests` and `field_changes` tables


## Changes

**`internal/changerequest/types.go`**
Added `ResourceChangeRequestPayload`, `ResourceFields`, and `ResourceChangeRequest` types. A separate payload struct was needed because resources use a flat `change_request: { field: value }` shape. Fields are `*string` pointers so absent fields are `nil` and don't overwrite existing DB values.

**`internal/db/resources.go`**
Added `UpdateResource` — runs a transaction that updates the resources table, inserts a `change_requests` row, and inserts one `field_changes` row per changed field. Uses the existing `buildUpdateQuery` helper with an explicit allowlist of the 8 fields the frontend sends.

**`internal/changerequest/manager.go`**
Added `UpdateResource` HTTP handler. Also fixed two issues caught during testing: `fieldChangesResponse` initialized as `[]FieldChange{}` (not nil) so it marshals to `[]` not `null`; `writeStatus(201)` called before `writeJson()` so the status code is committed before the body is written.

**`cmd/sheltertech-go/main.go`**
Added route: `r.Post("/api/resources/{id}/change_requests", changeRequestManager.UpdateResource)`

## Design decisions

- **No approve/reject lifecycle** —  the Ruby codebase has an approve/reject flow but it's legacy debt. persist_change (which applies the update to the DB) is called on both create AND approve, meaning data is written twice. The Go migration applies the change immediately on creation, consistent with how the phone handler works. Approve/reject can be layered in later.
- **Allowlist over passthrough** — Ruby's resource change request has no permitted_fields restriction, accepting any column. The Go implementation uses an explicit allowlist of the 8 fields the frontend actually sends, keeping the surface area intentional and safe.

## Testing

Integration tests added to `resources_integration_test.go`:

- **SingleField** — happy path, asserts 201 + correct response shape + field in `field_changes`
- **EmptyBody** — `change_request: {}` returns 201 with empty `field_changes` array
- **InvalidID** — non-numeric resource ID returns 400
- **MultipleFields** — 3 fields sent, all 3 returned; uses `ElementsMatch` since map iteration order is non-deterministic


```bash
go test -v -tags=integration -run "TestCreateResourceChangeRequest" ./cmd/sheltertech-go/...
```

## The flow being mapped 

| Step | Ruby | Go |
|---|---|---|
| 1. Receive request | Rails router → `ChangeRequestsController#create` | `r.Post(...)` → `Manager.UpdateResource` |
| 2. Parse body | `params[:change_request]` | `json.Unmarshal` into `ResourceChangeRequestPayload` → `ResourceFields` |
| 3. Start transaction | ActiveRecord implicit | `tx.Begin()` |
| 4. Update resource row | `resource.update(field_change_hash)` | `tx.Exec(buildUpdateQuery(...))` |
| 5. Insert change request record | `ResourceChangeRequest.create(...)` | `tx.QueryRow(insertChangeRequestSql, "ResourceChangeRequest", ...)` |
| 6. Insert field change rows | saved via association | `tx.Exec(insertFieldChangeSql, ...)` per field |
| 7. Commit | ActiveRecord implicit | `tx.Commit()` |
| 8. Return response | Rails renders JSON | `writeStatus(201)` + `writeJson(response)` |
