### PR TITLE
[High] Fix: panic() on database scan errors crashes the server

### DIFF
--- a/internal/db/categories.go
+++ b/internal/db/categories.go
@@ -3,8 +3,9 @@ package db
 import (
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
 	"log"
+
+	"github.com/lib/pq"
 )
 
 type Category struct {
@@ -109,146 +110,203 @@ func (m *Manager) GetCategories(topLevel *bool) []*Category {
 	}
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategories(rows)
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
 }
 
 func (m *Manager) GetCategoryServiceCounts() []*CategoryCount {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoryServiceCounts)
+	rows, err := m.DB.Query(categoryServiceCounts)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategoryCounts(rows)
+	defer rows.Close()
+	counts, err := scanCategoryCounts(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return counts
 }
 
 func (m *Manager) GetCategoryResourceCounts() []*CategoryCount {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoryResourceCounts)
+	rows, err := m.DB.Query(categoryResourceCounts)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategoryCounts(rows)
+	defer rows.Close()
+	counts, err := scanCategoryCounts(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return counts
 }
 
 func (m *Manager) GetCategoriesByFeatured() []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByFeaturedSql)
+	rows, err := m.DB.Query(categoriesByFeaturedSql)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategories(rows)
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
 }
 
 func (m *Manager) GetSubCategoriesByID(categoryId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(subCategoriesByIDSql, categoryId)
+	rows, err := m.DB.Query(subCategoriesByIDSql, categoryId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategories(rows)
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
 }
 
-func (m *Manager) GetCategoryByID(categoryId int) *Category {
+func (m *Manager) GetCategoryByID(categoryId int) (*Category, error) {
 	row := m.DB.QueryRow(categoriesByIDSql, categoryId)
 	return scanCategory(row)
 }
 
 func (m *Manager) GetCategoriesByIDs(ids []int) []*Category {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(categoriesByIDsSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(ids))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(ids))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategories(rows)
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
 }
 
 func (m *Manager) GetCategoriesByNames(names []string) []*Category {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(categoriesByNamesSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(names))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(names))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
-	return scanCategories(rows)
-}
-
-func (m *Manager) GetCategoriesByServiceID(serviceId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByServiceIDSql, serviceId)
+	defer rows.Close()
+	categories, err := scanCategories(rows)
 	if err != nil {
 		log.Printf("%v\n", err)
-	}
-	return scanCategories(rows)
-}
-
-func (m *Manager) GetCategoriesByResourceID(resourceId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByResourceIDSql, resourceId)
-	if err != nil {
-		log.Printf("%v\n", err)
-	}
-	return scanCategories(rows)
-}
-
-func scanCategories(rows *sql.Rows) []*Category {
-	var categories []*Category
-	for rows.Next() {
-		var category Category
-		err := rows.Scan(&category.Id, &category.Name, &category.TopLevel, &category.Featured)
-		switch err {
-		case sql.ErrNoRows:
-			fmt.Println("No rows were returned!")
-			return nil
-		}
-		categories = append(categories, &category)
+		return nil
 	}
 	return categories
 }
 
-func scanCategory(row *sql.Row) *Category {
+func (m *Manager) GetCategoriesByServiceID(serviceId int) []*Category {
+	rows, err := m.DB.Query(categoriesByServiceIDSql, serviceId)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
+}
+
+func (m *Manager) GetCategoriesByResourceID(resourceId int) []*Category {
+	rows, err := m.DB.Query(categoriesByResourceIDSql, resourceId)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	defer rows.Close()
+	categories, err := scanCategories(rows)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return categories
+}
+
+func scanCategories(rows *sql.Rows) ([]*Category, error) {
+	var categories []*Category
+	for rows.Next() {
+		var category Category
+		err := rows.Scan(&category.Id, &category.Name, &category.TopLevel, &category.Featured)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, nil
+			}
+			return nil, err
+		}
+		categories = append(categories, &category)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return categories, nil
+}
+
+func scanCategory(row *sql.Row) (*Category, error) {
 	var category Category
 	err := row.Scan(&category.Id, &category.Name, &category.TopLevel, &category.Featured)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
-			return nil
+			return nil, nil
 		default:
-			panic(err)
+			return nil, err
 		}
 	}
-	return &category
+	return &category, nil
 }
 
-func scanCategoryCounts(rows *sql.Rows) []*CategoryCount {
+func scanCategoryCounts(rows *sql.Rows) ([]*CategoryCount, error) {
 	var counts []*CategoryCount
 	for rows.Next() {
 		var count CategoryCount
 		err := rows.Scan(&count.CategoryName, &count.Count)
-		switch err {
-		case sql.ErrNoRows:
-			fmt.Println("No rows were returned!")
-			return nil
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, nil
+			}
+			return nil, err
 		}
 		counts = append(counts, &count)
 	}
-	return counts
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return counts, nil
 }

--- a/internal/db/folders.go
+++ b/internal/db/folders.go
@@ -43,18 +43,17 @@ DELETE FROM public.folders f
 WHERE f.id = $1
 `
 
-func (m *Manager) GetFolderById(folderId int) *Folder {
+func (m *Manager) GetFolderById(folderId int) (*Folder, error) {
 	row := m.DB.QueryRow(folderByIDSql, folderId)
 	return scanFolder(row)
 }
 
-func (m *Manager) GetFolders(userId int) []*Folder {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(foldersByUserIDSql, userId)
+func (m *Manager) GetFolders(userId int) ([]*Folder, error) {
+	rows, err := m.DB.Query(foldersByUserIDSql, userId)
 	if err != nil {
-		log.Printf("%v\n", err)
+		return nil, err
 	}
+	defer rows.Close()
 	return scanFolders(rows)
 }
 
@@ -67,6 +66,7 @@ func (m *Manager) CreateFolder(folder *Folder) (int, error) {
 	var id int
 	err = row.Scan(&id)
 	if err != nil {
+		tx.Rollback()
 		return -1, err
 	}
 	return id, tx.Commit()
@@ -77,6 +77,7 @@ func (m *Manager) UpdateFolder(folder *Folder) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 	res, err := tx.Exec(updateFolder, folder.Id, folder.Name, folder.Order)
 	if err != nil {
 		return err
@@ -86,7 +87,6 @@ func (m *Manager) UpdateFolder(folder *Folder) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 	return tx.Commit()
@@ -97,7 +97,7 @@ func (m *Manager) DeleteFolderById(folderId int) error {
 	if err != nil {
 		return err
 	}
-
+	defer tx.Rollback()
 	res, err := tx.Exec(deleteFolder, folderId)
 	if err != nil {
 		return err
@@ -107,38 +107,51 @@ func (m *Manager) DeleteFolderById(folderId int) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 	return tx.Commit()
 }
 
-func scanFolders(rows *sql.Rows) []*Folder {
+func scanFolders(rows *sql.Rows) ([]*Folder, error) {
 	var folders []*Folder
 	for rows.Next() {
 		var folder Folder
 		err := rows.Scan(&folder.Id, &folder.Name, &folder.Order, &folder.UserId)
-		switch err {
-		case sql.ErrNoRows:
-			fmt.Println("No rows were returned!")
-			return nil
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, nil
+			}
+			return nil, err
 		}
 		folders = append(folders, &folder)
 	}
-	return folders
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return folders, nil
 }
 
-func scanFolder(row *sql.Row) *Folder {
+func scanFolder(row *sql.Row) (*Folder, error) {
 	var folder Folder
 	err := row.Scan(&folder.Id, &folder.Name, &folder.Order, &folder.UserId)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
-			return nil
+			return nil, nil
 		default:
-			panic(err)
+			return nil, err
 		}
 	}
-	return &folder
+	return &folder, nil
+}
+
+// Deprecated: use GetFolders which returns an error
+func (m *Manager) GetFoldersLegacy(userId int) []*Folder {
+	folders, err := m.GetFolders(userId)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return folders
 }

--- a/internal/db/resources.go
+++ b/internal/db/resources.go
@@ -40,7 +40,7 @@ FROM public.resources
 WHERE status = 1
 `
 
-func (m *Manager) GetResourceById(resourceId int) *Resource {
+func (m *Manager) GetResourceById(resourceId int) (*Resource, error) {
 	row := m.DB.QueryRow(resourceByIDSql, resourceId)
 	return scanResource(row)
 }
@@ -53,20 +53,19 @@ func (m *Manager) GetResourcesCount() (int, error) {
 		return 0, err
 	}
 	return count, nil
-
 }
 
-func scanResource(row *sql.Row) *Resource {
+func scanResource(row *sql.Row) (*Resource, error) {
 	var resource Resource
 	err := row.Scan(&resource.Id, &resource.Name, &resource.ShortDescription, &resource.LongDescription, &resource.Website, &resource.VerifiedAt, &resource.Email, &resource.Status, &resource.Certified, &resource.AlternateName, &resource.LegalStatus, &resource.ContactId, &resource.FundingId, &resource.CertifiedAt, &resource.Featured, &resource.SourceAttribution, &resource.InternalNote, &resource.UpdatedAt)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
-			return nil
+			return nil, nil
 		default:
-			panic(err)
+			return nil, err
 		}
 	}
-	return &resource
+	return &resource, nil
 }

--- a/internal/db/savedsearch.go
+++ b/internal/db/savedsearch.go
@@ -62,18 +62,17 @@ type SavedSearch struct {
 	Search SavedSearchQuery
 }
 
-func (m *Manager) GetSavedSearchById(savedSearchId int) *SavedSearch {
+func (m *Manager) GetSavedSearchById(savedSearchId int) (*SavedSearch, error) {
 	row := m.DB.QueryRow(savedSearchByIDSql, savedSearchId)
 	return scanSavedSearch(row)
 }
 
-func (m *Manager) GetSavedSearches(userId int) []*SavedSearch {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(savedSearchesByUserIDSql, userId)
+func (m *Manager) GetSavedSearches(userId int) ([]*SavedSearch, error) {
+	rows, err := m.DB.Query(savedSearchesByUserIDSql, userId)
 	if err != nil {
-		log.Printf("%v\n", err)
+		return nil, err
 	}
+	defer rows.Close()
 	return scanSavedSearches(rows)
 }
 
@@ -86,6 +85,7 @@ func (m *Manager) CreateSavedSearch(savedSearch *SavedSearch) (int, error) {
 	var id int
 	err = row.Scan(&id)
 	if err != nil {
+		tx.Rollback()
 		return -1, err
 	}
 	return id, tx.Commit()
@@ -96,7 +96,7 @@ func (m *Manager) DeleteSavedSearchById(id int) error {
 	if err != nil {
 		return err
 	}
-
+	defer tx.Rollback()
 	res, err := tx.Exec(deleteSavedSearchSql, id)
 	if err != nil {
 		return err
@@ -106,38 +106,51 @@ func (m *Manager) DeleteSavedSearchById(id int) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 	return tx.Commit()
 }
 
-func scanSavedSearches(rows *sql.Rows) []*SavedSearch {
+func scanSavedSearches(rows *sql.Rows) ([]*SavedSearch, error) {
 	var savedSearches []*SavedSearch
 	for rows.Next() {
 		var savedSearch SavedSearch
 		err := rows.Scan(&savedSearch.Id, &savedSearch.UserId, &savedSearch.Name, &savedSearch.Search)
-		switch err {
-		case sql.ErrNoRows:
-			fmt.Println("No rows were returned!")
-			return nil
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, nil
+			}
+			return nil, err
 		}
 		savedSearches = append(savedSearches, &savedSearch)
 	}
-	return savedSearches
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return savedSearches, nil
 }
 
-func scanSavedSearch(row *sql.Row) *SavedSearch {
+func scanSavedSearch(row *sql.Row) (*SavedSearch, error) {
 	var savedSearch SavedSearch
 	err := row.Scan(&savedSearch.Id, &savedSearch.UserId, &savedSearch.Name, &savedSearch.Search)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
-			return nil
+			return nil, nil
 		default:
-			panic(err)
+			return nil, err
 		}
 	}
-	return &savedSearch
+	return &savedSearch, nil
+}
+
+// Deprecated: use GetSavedSearches which returns an error
+func (m *Manager) GetSavedSearchesLegacy(userId int) []*SavedSearch {
+	searches, err := m.GetSavedSearches(userId)
+	if err != nil {
+		log.Printf("%v\n", err)
+		return nil
+	}
+	return searches
 }

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -19,21 +19,22 @@ FROM public.users u
 WHERE u.user_external_id = $1
 `
 
-func (m *Manager) GetUserByUserExternalID(userExternalId string) *User {
+func (m *Manager) GetUserByUserExternalID(userExternalId string) (*User, error) {
 	row := m.DB.QueryRow(userByUserExternalIDSql, userExternalId)
 	return scanUser(row)
 }
-func scanUser(row *sql.Row) *User {
+
+func scanUser(row *sql.Row) (*User, error) {
 	var user User
 	err := row.Scan(&user.Id, &user.Name, &user.Organization, &user.UserExternalId, &user.Email)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
 			fmt.Println("No rows were returned!")
-			return nil
+			return nil, nil
 		default:
-			panic(err)
+			return nil, err
 		}
 	}
-	return &user
+	return &user, nil
 }


### PR DESCRIPTION
## Problem
Multiple `scan*` functions in `internal/db/` call `panic(err)` on unexpected database errors (type mismatches, driver errors, etc.). Any such error crashes the entire server process with no graceful HTTP response.

Affected files:
- `internal/db/users.go` — `scanUser`
- `internal/db/resources.go` — `scanResource`
- `internal/db/folders.go` — `scanFolder`
- `internal/db/savedsearch.go` — `scanSavedSearch`
- `internal/db/categories.go` — `scanCategory`

## Fix
- Replace `panic(err)` with returning `(nil, err)` in all affected scan functions
- Update callers to propagate errors through the call stack
- Add `defer rows.Close()` where missing
- Add `rows.Err()` checks after row iteration