### PR TITLE
[High] Fix: non-deterministic map iteration causes data corruption in query builder

### DIFF
--- a/internal/db/utils.go
+++ b/internal/db/utils.go
@@ -2,25 +2,34 @@ package db
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
 // buildUpdateQuery builds "UPDATE table SET col1=$1, col2=$2, ..., updated_at=now() WHERE idCol=$n".
-// Only keys in allowedColumns are used. Returns query and args.
+// Only keys in allowedColumns are used. Keys are sorted to guarantee deterministic parameter ordering.
+// Returns query and args.
 func buildUpdateQuery(table, idCol string, id int, updates map[string]interface{}, allowedColumns []string) (string, []interface{}) {
 	allowedSet := make(map[string]bool)
 	for _, c := range allowedColumns {
 		allowedSet[c] = true
 	}
+
+	// Collect and sort allowed keys for deterministic ordering
+	var keys []string
+	for key := range updates {
+		if allowedSet[key] {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
 	var setParts []string
 	var args []interface{}
 	pos := 1
-	for key, val := range updates {
-		if !allowedSet[key] {
-			continue
-		}
+	for _, key := range keys {
 		setParts = append(setParts, fmt.Sprintf("%s=$%d", key, pos))
-		args = append(args, val)
+		args = append(args, updates[key])
 		pos++
 	}
 	setParts = append(setParts, "updated_at=now()")
@@ -32,23 +41,31 @@ func buildUpdateQuery(table, idCol string, id int, updates map[string]interface{
 }
 
 // buildInsertQuery builds "INSERT INTO table (col1, col2, ..., created_at, updated_at) VALUES ($1, $2, ..., now(), now()) RETURNING id".
-// Only keys in allowedColumns are used. Returns query and args.
+// Only keys in allowedColumns are used. Keys are sorted to guarantee deterministic parameter ordering.
+// Returns query and args.
 func buildInsertQuery(table string, values map[string]interface{}, allowedColumns []string) (string, []interface{}) {
 	allowedSet := make(map[string]bool)
 	for _, c := range allowedColumns {
 		allowedSet[c] = true
 	}
+
+	// Collect and sort allowed keys for deterministic ordering
+	var keys []string
+	for key := range values {
+		if allowedSet[key] {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
 	var colParts []string
 	var valParts []string
 	var args []interface{}
 	pos := 1
-	for key, val := range values {
-		if !allowedSet[key] {
-			continue
-		}
-		colParts = append(colParts, fmt.Sprintf("%s", key))
+	for _, key := range keys {
+		colParts = append(colParts, key)
 		valParts = append(valParts, fmt.Sprintf("$%d", pos))
-		args = append(args, val)
+		args = append(args, values[key])
 		pos++
 	}
 	colParts = append(colParts, "created_at, updated_at")


### PR DESCRIPTION
## Problem
`buildUpdateQuery` and `buildInsertQuery` in `internal/db/utils.go` iterate over a Go `map[string]interface{}` to build positional SQL parameters (`$1`, `$2`, etc.). Go map iteration order is randomized per run, meaning the positional parameters will not consistently map to the correct argument values. This is a **data corruption bug** for any write path that uses these functions (phone insert/update via `internal/db/phones.go`).

## Fix
Sort the allowed keys alphabetically before building the query, guaranteeing deterministic parameter ordering on every call.