### PR TITLE
[High] Fix: GET /api/bookmarks returns all users' bookmarks without filtering

### DIFF
--- a/internal/bookmarks/manager.go
+++ b/internal/bookmarks/manager.go
@@ -2,7 +2,7 @@ package bookmarks
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -25,33 +25,26 @@ func New(dbManager *db.Manager) *Manager {
 }
 
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
-
-	var dbBookmarks []*db.Bookmark
-
 	userId := r.URL.Query().Get("user_id")
-
-	if userId != "" {
-		iUserId, err := strconv.Atoi(userId)
-		if err != nil {
-			log.Printf("%v", err)
-			common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		dbBookmarks, err = m.DbClient.GetBookmarksByUserID(iUserId)
-		if err != nil {
-			log.Printf("%v", err)
-			common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
-			return
-		}
-	} else {
-		var err error
-		dbBookmarks, err = m.DbClient.GetBookmarks()
-		if err != nil {
-			log.Printf("%v", err)
-			common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
-			return
-		}
+	if userId == "" {
+		common.WriteErrorJson(w, http.StatusBadRequest, "user_id query parameter is required")
+		return
 	}
+
+	iUserId, err := strconv.Atoi(userId)
+	if err != nil {
+		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	dbBookmarks, err := m.DbClient.GetBookmarksByUserID(iUserId)
+	if err != nil {
+		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+		return
+	}
+
 	response := Bookmarks{
 		Bookmarks: FromDBTypeArray(dbBookmarks),
 	}
@@ -82,10 +75,15 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
-	body, _ := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
 
 	bookmark := &Bookmark{}
-	err := json.Unmarshal(body, bookmark)
+	err = json.Unmarshal(body, bookmark)
 	if err != nil {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
@@ -108,16 +106,21 @@ func (m *Manager) Submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeStatus(w, http.StatusCreated)
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
-	body, _ := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
 
 	bookmark := &Bookmark{}
-	err := json.Unmarshal(body, bookmark)
+	err = json.Unmarshal(body, bookmark)
 	if err != nil {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
@@ -141,8 +144,7 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeStatus(w, http.StatusCreated)
-
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (m *Manager) DeleteByID(w http.ResponseWriter, r *http.Request) {
@@ -159,22 +161,18 @@ func (m *Manager) DeleteByID(w http.ResponseWriter, r *http.Request) {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, err.Error())
 	}
-
 }
 
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		log.Println("error:", err)
+		log.Printf("error: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
-}
-
-func writeStatus(w http.ResponseWriter, responseStatus int) {
-	w.WriteHeader(responseStatus)
 }

--- a/internal/db/bookmarks.go
+++ b/internal/db/bookmarks.go
@@ -19,9 +19,6 @@ type Bookmark struct {
 	UpdatedAt  sql.NullTime
 }
 
-const findBookmarksSql = `
-SELECT id, "order", user_id, folder_id, service_id, resource_id, name from public.bookmarks`
-
 const findBookmarksByUserIDSql = `
 SELECT id, "order", user_id, folder_id, service_id, resource_id, name from public.bookmarks WHERE user_id=$1`
 
@@ -39,36 +36,19 @@ const deleteBookmarkByIDSql = `
 DELETE FROM public.bookmarks WHERE id = $1
 `
 
-// const bookmarksByFolderIDSQL = `
-// SELECT b.if, b.order, b.service_id
-// FROM public.bookmarks b
-// WHERE b.folder_id = $1
-// `
-
-func (m *Manager) GetBookmarks() ([]*Bookmark, error) {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(findBookmarksSql)
-	if err != nil {
-		log.Printf("%v\n", err)
-	}
-	return scanBookmarks(rows), err
-}
-
 func (m *Manager) GetBookmarkByID(bookmarkId int) (*Bookmark, error) {
 	row := m.DB.QueryRow(findBookmarksByIDSql, bookmarkId)
 	return scanBookmark(row)
 }
 
 func (m *Manager) GetBookmarksByUserID(userId int) ([]*Bookmark, error) {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(findBookmarksByUserIDSql, userId)
+	rows, err := m.DB.Query(findBookmarksByUserIDSql, userId)
 	if err != nil {
 		log.Printf("%v\n", err)
 		return nil, err
 	}
-	return scanBookmarks(rows), err
+	defer rows.Close()
+	return scanBookmarks(rows)
 }
 
 func (m *Manager) SubmitBookmark(bookmark *Bookmark) error {
@@ -76,6 +56,7 @@ func (m *Manager) SubmitBookmark(bookmark *Bookmark) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 	res, err := tx.Exec(submitBookmark, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID, bookmark.Name)
 	if err != nil {
 		return err
@@ -86,7 +67,6 @@ func (m *Manager) SubmitBookmark(bookmark *Bookmark) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 
@@ -98,6 +78,7 @@ func (m *Manager) UpdateBookmark(bookmark *Bookmark) error {
 	if err != nil {
 		return err
 	}
+	defer tx.Rollback()
 	res, err := tx.Exec(updateBookmark, bookmark.Id, bookmark.Order, bookmark.UserID, bookmark.FolderID, bookmark.ResourceID, bookmark.ServiceID, bookmark.Name)
 	if err != nil {
 		return err
@@ -108,7 +89,6 @@ func (m *Manager) UpdateBookmark(bookmark *Bookmark) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 	return tx.Commit()
@@ -119,7 +99,7 @@ func (m *Manager) DeleteBookmarkByID(bookmarkId int) error {
 	if err != nil {
 		return err
 	}
-
+	defer tx.Rollback()
 	res, err := tx.Exec(deleteBookmarkByIDSql, bookmarkId)
 	if err != nil {
 		return err
@@ -129,25 +109,25 @@ func (m *Manager) DeleteBookmarkByID(bookmarkId int) error {
 		return err
 	}
 	if rowCount != 1 {
-		defer tx.Rollback()
 		return errors.New(fmt.Sprintf("unexpected rows modified, expected one, saw %v", rowCount))
 	}
 	return tx.Commit()
 }
 
-func scanBookmarks(rows *sql.Rows) []*Bookmark {
+func scanBookmarks(rows *sql.Rows) ([]*Bookmark, error) {
 	var bookmarks []*Bookmark
 	for rows.Next() {
 		var bookmark Bookmark
 		err := rows.Scan(&bookmark.Id, &bookmark.Order, &bookmark.UserID, &bookmark.FolderID, &bookmark.ServiceID, &bookmark.ResourceID, &bookmark.Name)
-		switch err {
-		case sql.ErrNoRows:
-			fmt.Println("No rows were returned!")
-			return nil
+		if err != nil {
+			return nil, err
 		}
 		bookmarks = append(bookmarks, &bookmark)
 	}
-	return bookmarks
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return bookmarks, nil
 }
 
 func scanBookmark(row *sql.Row) (*Bookmark, error) {


### PR DESCRIPTION
## Problem
`GET /api/bookmarks` without a `user_id` query parameter executes a SQL query with no `WHERE` clause, returning **every bookmark in the database** to the caller. Even though the route requires authentication (when `ENABLE_JWT_VERIFICATION=true`), any authenticated user can read any other user's bookmarks.

## Fix
- Remove the unfiltered `GetBookmarks` DB method (no valid use case for returning all bookmarks)
- Make `user_id` a **required** query parameter on `GET /api/bookmarks` — returns `400 Bad Request` if missing
- Also replaces deprecated `ioutil.ReadAll` with `io.ReadAll`