### PR TITLE
[Medium] Fix: panic() on HTTP write errors in writeJson across all packages

### DIFF
--- a/internal/categories/manager.go
+++ b/internal/categories/manager.go
@@ -2,7 +2,6 @@ package categories
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -24,15 +23,6 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
-// Get lists all existing categories
-//
-//	@Summary		Get Categories
-//	@Description	get all categories
-//	@Tags			categories
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{array}	categories.Categories
-//	@Router			/categories [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	topLevelString := r.URL.Query().Get("top_level")
 	var topLevel *bool
@@ -51,13 +41,10 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
-	// Get all categories first
 	allCategories := m.DbClient.GetCategories(nil)
 
-	// Create a map to store service and resource counts
 	countsMap := make(map[string]CategoryCountDTO)
 
-	// Initialize all categories with 0 counts
 	for _, category := range allCategories {
 		countsMap[category.Name] = CategoryCountDTO{
 			Name:      category.Name,
@@ -66,7 +53,6 @@ func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	// Add service counts
 	serviceCounts := m.DbClient.GetCategoryServiceCounts()
 	for _, serviceCount := range serviceCounts {
 		if dto, exists := countsMap[serviceCount.CategoryName]; exists {
@@ -75,7 +61,6 @@ func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	// Add resource counts
 	resourceCounts := m.DbClient.GetCategoryResourceCounts()
 	for _, resourceCount := range resourceCounts {
 		if dto, exists := countsMap[resourceCount.CategoryName]; exists {
@@ -84,13 +69,11 @@ func (m *Manager) GetCategoryCounts(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	// Convert to array and sort by name (alphabetical order)
 	var response []CategoryCountDTO
 	for _, dto := range countsMap {
 		response = append(response, dto)
 	}
 
-	// Sort by name to match Rails API order
 	sort.Slice(response, func(i, j int) bool {
 		return response[i].Name < response[j].Name
 	})
@@ -103,7 +86,12 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("%v", err)
 	}
-	dbCategory := m.DbClient.GetCategoryByID(categoryId)
+	dbCategory, err := m.DbClient.GetCategoryByID(categoryId)
+	if err != nil {
+		log.Printf("%v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
 	writeJson(w, FromDBType(dbCategory))
 }
 
@@ -130,12 +118,13 @@ func (m *Manager) GetByFeatured(w http.ResponseWriter, _ *http.Request) {
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		fmt.Println("error:", err)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }

--- a/internal/folders/manager.go
+++ b/internal/folders/manager.go
@@ -2,8 +2,7 @@ package folders
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -23,49 +22,40 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
-// Get lists folders for current user
-// (note - I don't have the user auth stuff here)
-//
-//	@Summary		Get Folders for current User
-//	@Description	get folders for user
-//	@Tags			folders
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{array}	folders.Folders
-//	@Router			/folders [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	userId, err := strconv.Atoi(r.URL.Query().Get("user_id"))
 	if err != nil {
-		fmt.Println("error:", err)
-		writeStatus(w, http.StatusBadRequest)
+		log.Printf("error: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	dbFolders := m.DbClient.GetFolders(userId)
+	dbFolders, err := m.DbClient.GetFolders(userId)
+	if err != nil {
+		log.Printf("error: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	response := Folders{
 		Folders: FromDBTypeArray(dbFolders),
 	}
 	writeJson(w, response)
 }
 
-// Create folder for current user
-// (note - I don't have the user auth stuff here)
-//
-//	@Summary		Create Folder for current User
-//	@Description	new folder for user
-//	@Tags			folders
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	folders.Folder
-//	@Router			/folders [post]
 func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, _ := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("error reading body: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	folder := &Folder{}
-	err := json.Unmarshal(body, folder)
+	err = json.Unmarshal(body, folder)
 	if err != nil {
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	dbFolder := &db.Folder{
@@ -77,67 +67,60 @@ func (m *Manager) Post(w http.ResponseWriter, r *http.Request) {
 	folderId, err := m.DbClient.CreateFolder(dbFolder)
 	if err != nil {
 		log.Print(err)
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	dbFolder = m.DbClient.GetFolderById(folderId)
+	dbFolder, err = m.DbClient.GetFolderById(folderId)
+	if err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if dbFolder == nil {
 		// This really shouldn't happen, since we just created it.
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	writeStatus(w, http.StatusCreated)
+	w.WriteHeader(http.StatusCreated)
 	writeJson(w, FromDBType(dbFolder))
 }
 
-// Get folder by ID
-// (note - I don't have the user auth stuff here)
-//
-//	@Summary		Get folder by ID
-//	@Description	get current folder for user
-//	@Tags			folders
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	folders.Folder
-//	@Router			/folders/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	folderId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		log.Printf("%v", err)
-		writeStatus(w, http.StatusBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
 		return
-
 	}
-	dbFolder := m.DbClient.GetFolderById(folderId)
+	dbFolder, err := m.DbClient.GetFolderById(folderId)
+	if err != nil {
+		log.Printf("%v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if dbFolder == nil {
-		writeStatus(w, http.StatusNotFound)
+		w.WriteHeader(http.StatusNotFound)
 	} else {
 		writeJson(w, FromDBType(dbFolder))
 	}
 }
 
-// Update folder by ID
-// not done
-
-// (note - I don't have the user auth stuff here)
-//
-//	@Summary		Update folder by ID
-//	@Description	update a folder for user
-//	@Tags			folders
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	folders.Folder
-//	@Router			/folders/{id} [put]
 func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	body, _ := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("error reading body: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	folder := &Folder{}
-	err := json.Unmarshal(body, folder)
+	err = json.Unmarshal(body, folder)
 	if err != nil {
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	dBFolder := &db.Folder{
@@ -149,50 +132,40 @@ func (m *Manager) Put(w http.ResponseWriter, r *http.Request) {
 	err = m.DbClient.UpdateFolder(dBFolder)
 	if err != nil {
 		log.Print(err)
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
-	writeStatus(w, http.StatusCreated)
+	w.WriteHeader(http.StatusCreated)
 }
 
-// Delete folder by ID
-// not done
-// (note - I don't have the user auth stuff here)
-//
-//	@Summary		Delete folder by ID
-//	@Description	delete a folder for user
-//	@Tags			folders
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{object}	folders.Folder
-//	@Router			/folders/{id} [delete]
 func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 	folderId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		log.Printf("%v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	err = m.DbClient.DeleteFolderById(folderId)
 	if err != nil {
 		log.Print(err)
-		writeStatus(w, http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
-	writeStatus(w, http.StatusNoContent)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		fmt.Println("error:", err)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
-}
-
-func writeStatus(w http.ResponseWriter, responseStatus int) {
-	w.WriteHeader(responseStatus)
 }

--- a/internal/news_articles/manager.go
+++ b/internal/news_articles/manager.go
@@ -23,20 +23,7 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
-// Create news article
-//
-//	@Summary        Create News Article
-//	@Description    Create a new news article
-//	@Tags           news_articles
-//	@Accept         json
-//	@Produce        json
-//	@Param          body body newsarticles.NewsArticleCreateRequest true "News article data"
-//	@Success        201 {object} newsarticles.NewsArticle
-//	@Failure        400 {object} error "Invalid request body"
-//	@Failure        500 {object} error "Internal server error"
-//	@Router         /news_articles [post]
 func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
-	// Parse request body
 	var createReq NewsArticleCreateRequest
 	err := json.NewDecoder(r.Body).Decode(&createReq)
 	if err != nil {
@@ -45,7 +32,6 @@ func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create new news article
 	newsArticle, err := m.DbClient.CreateNewsArticle(
 		createReq.Headline,
 		createReq.Body,
@@ -60,22 +46,11 @@ func (m *Manager) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return the created news article
 	response := FromNewsArticleDBType(newsArticle)
 	writeJson(w, response, http.StatusCreated)
 }
 
-// Get all news articles
-//
-//	@Summary        Get News Articles
-//	@Description    Get all news articles with optional filtering for active articles only
-//	@Tags           news_articles
-//	@Produce        json
-//	@Param          active query boolean false "Filter for active news articles only"
-//	@Success        200 {array} newsarticles.NewsArticle
-//	@Router         /news_articles [get]
 func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
-	// Check for unexpected query parameters
 	validParams := map[string]bool{"active": true}
 
 	for param := range r.URL.Query() {
@@ -100,22 +75,7 @@ func (m *Manager) Get(w http.ResponseWriter, r *http.Request) {
 	writeJson(w, response, http.StatusOK)
 }
 
-// Update news article
-//
-//	@Summary        Update News Article
-//	@Description    Update an existing news article
-//	@Tags           news_articles
-//	@Accept         json
-//	@Produce        json
-//	@Param          id path integer true "News Article ID"
-//	@Param          body body newsarticles.NewsArticleUpdateRequest true "News article update data"
-//	@Success        200 {object} newsarticles.NewsArticle
-//	@Failure        400 {object} error "Invalid request body"
-//	@Failure        404 {object} error "News article not found"
-//	@Failure        500 {object} error "Internal server error"
-//	@Router         /news_articles/{id} [put]
 func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
-	// Get the ID from the URL parameters
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
@@ -124,7 +84,6 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse request body
 	var updateReq NewsArticleUpdateRequest
 	err = json.NewDecoder(r.Body).Decode(&updateReq)
 	if err != nil {
@@ -133,14 +92,12 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the existing news article
 	newsArticles := m.DbClient.GetNewsArticlesByIDs([]int{id})
 	if len(newsArticles) == 0 {
 		common.WriteErrorJson(w, http.StatusNotFound, fmt.Sprintf("News article with ID %d not found", id))
 		return
 	}
 
-	// Update the news article
 	updatedNewsArticle, err := m.DbClient.UpdateNewsArticle(
 		id,
 		updateReq.Headline,
@@ -156,24 +113,11 @@ func (m *Manager) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return the updated news article
 	response := FromNewsArticleDBType(updatedNewsArticle)
 	writeJson(w, response, http.StatusOK)
 }
 
-// Delete news article
-//
-//	@Summary        Delete News Article
-//	@Description    Delete an existing news article
-//	@Tags           news_articles
-//	@Param          id path integer true "News Article ID"
-//	@Success        200 {object} object "Empty response on success"
-//	@Failure        400 {object} error "Invalid news article ID format"
-//	@Failure        404 {object} error "News article not found"
-//	@Failure        500 {object} error "Internal server error"
-//	@Router         /news_articles/{id} [delete]
 func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
-	// Get the ID from the URL parameters
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
@@ -182,14 +126,12 @@ func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if the news article exists
 	newsArticles := m.DbClient.GetNewsArticlesByIDs([]int{id})
 	if len(newsArticles) == 0 {
 		common.WriteErrorJson(w, http.StatusNotFound, fmt.Sprintf("News article with ID %d not found", id))
 		return
 	}
 
-	// Delete the news article
 	err = m.DbClient.DeleteNewsArticle(id)
 	if err != nil {
 		log.Printf("%v", err)
@@ -197,21 +139,19 @@ func (m *Manager) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return success
 	w.WriteHeader(http.StatusOK)
 }
 
 func writeJson(w http.ResponseWriter, object interface{}, status int) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		log.Printf("%v", err)
-		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }

--- a/internal/resources/manager.go
+++ b/internal/resources/manager.go
@@ -2,7 +2,10 @@ package resources
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/sheltertechsf/sheltertech-go/internal/addresses"
 	"github.com/sheltertechsf/sheltertech-go/internal/categories"
@@ -11,9 +14,6 @@ import (
 	"github.com/sheltertechsf/sheltertech-go/internal/notes"
 	"github.com/sheltertechsf/sheltertech-go/internal/phones"
 	"github.com/sheltertechsf/sheltertech-go/internal/schedules"
-	"log"
-	"net/http"
-	"strconv"
 )
 
 type Manager struct {
@@ -27,22 +27,20 @@ func New(dbManager *db.Manager) *Manager {
 	return manager
 }
 
-// GetByID Get a resource by ID
-//
-//	@Summary		Get Resource
-//	@Description	gets a single service by resource ID
-//	@Tags			resources
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{array}	resources.Resource
-//	@Router			/resources/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	resourceId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusBadRequest, "invalid resource ID")
+		return
 	}
-	dbService := m.DbClient.GetResourceById(resourceId)
-	response := FromDBType(dbService)
+	dbResource, err := m.DbClient.GetResourceById(resourceId)
+	if err != nil {
+		log.Printf("%v", err)
+		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+		return
+	}
+	response := FromDBType(dbResource)
 	response.Schedule = schedules.FromDBType(m.DbClient.GetScheduleByResourceId(resourceId))
 	response.Categories = categories.FromDBTypeArray(m.DbClient.GetCategoriesByResourceID(resourceId))
 	response.Notes = notes.FromNoteDBTypeArray(m.DbClient.GetNotesByResourceID(resourceId))
@@ -60,23 +58,24 @@ func (m *Manager) GetCount(w http.ResponseWriter, r *http.Request) {
 	count, err := m.DbClient.GetResourcesCount()
 	if err != nil {
 		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+		return
 	}
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write([]byte(strconv.Itoa(count)))
-	if err != nil {
-		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+	if _, err = w.Write([]byte(strconv.Itoa(count))); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }
 
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		fmt.Println("error:", err)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -25,11 +25,11 @@ import (
 )
 
 type Manager struct {
-	DbClient         *db.Manager      // ← Same
-	TranslateService TranslateService // ← NEW: Injectable service
-	PDFService       PDFService       // ← NEW: Injectable service
-	GoogleConfig     GoogleConfig     // ← Same
-	PDFCrowdConfig   PDFCrowdConfig   // ← Same
+	DbClient         *db.Manager
+	TranslateService TranslateService
+	PDFService       PDFService
+	GoogleConfig     GoogleConfig
+	PDFCrowdConfig   PDFCrowdConfig
 }
 
 func New(dbManager *db.Manager, translateCredentials string, pdfCrowdUsername, pdfCrowdApiKey string) *Manager {
@@ -43,41 +43,32 @@ func New(dbManager *db.Manager, translateCredentials string, pdfCrowdUsername, p
 		Key:     pdfCrowdApiKey,
 	}
 
-	return NewWithDependencies( // ← NEW: Calls other constructor
+	return NewWithDependencies(
 		dbManager,
-		NewGoogleTranslateService(translateCredentials),                              // ← NEW: Creates real service
-		NewPDFCrowdService(pdfCrowdConfig.Enabled, pdfCrowdUsername, pdfCrowdApiKey), // ← NEW: Creates real service
+		NewGoogleTranslateService(translateCredentials),
+		NewPDFCrowdService(pdfCrowdConfig.Enabled, pdfCrowdUsername, pdfCrowdApiKey),
 		googleConfig,
 		pdfCrowdConfig,
 	)
 }
+
 func NewWithDependencies(
 	dbManager *db.Manager,
-	translateService TranslateService, // ← NEW: Accepts interface
-	pdfService PDFService, // ← NEW: Accepts interface
+	translateService TranslateService,
+	pdfService PDFService,
 	googleConfig GoogleConfig,
 	pdfCrowdConfig PDFCrowdConfig,
 ) *Manager {
 	return &Manager{
-		DbClient:         dbManager,        // ← Same as before
-		TranslateService: translateService, // ← NEW: Injected service
-		PDFService:       pdfService,       // ← NEW: Injected service
-		GoogleConfig:     googleConfig,     // ← Same as before
-		PDFCrowdConfig:   pdfCrowdConfig,   // ← Same as before
+		DbClient:         dbManager,
+		TranslateService: translateService,
+		PDFService:       pdfService,
+		GoogleConfig:     googleConfig,
+		PDFCrowdConfig:   pdfCrowdConfig,
 	}
 }
 
-// GetByID Get a service by ID
-//
-//	@Summary		Get Service
-//	@Description	gets a single service by service ID
-//	@Tags			services
-//	@Accept			json
-//	@Produce		json
-//	@Success		200	{array}	services.Service
-//	@Router			/services/{id} [get]
 func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
-	// Get the ID from the URL parameters
 	serviceId, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		log.Printf("%v", err)
@@ -85,7 +76,6 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Retrieve the service from the database
 	dbService, err := m.DbClient.GetServiceById(serviceId)
 	if err != nil {
 		log.Printf("%v", err)
@@ -93,7 +83,6 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Populate the response with service details
 	response := FromDBType(dbService)
 	response.Categories = categories.FromDBTypeArray(m.DbClient.GetCategoriesByServiceID(serviceId))
 	response.Notes = notes.FromNoteDBTypeArray(m.DbClient.GetNotesByServiceID(serviceId))
@@ -103,17 +92,14 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	response.Documents = documents.FromDocumentDBTypeArray(m.DbClient.GetDocumentsByServiceID(serviceId))
 	response.Schedule = schedules.FromDBType(m.DbClient.GetScheduleByServiceId(serviceId))
 
-	// Add program if available
 	if dbService.ProgramId.Valid {
 		response.Program = programs.FromDBProgramType(m.DbClient.GetProgramById(int(dbService.ProgramId.Int32)))
 	}
 
-	// Add resource if available
 	if dbService.ResourceId.Valid {
 		response.Resource = resources.FromDBType(m.DbClient.GetResourceById(int(dbService.ResourceId.Int32)))
 	}
 
-	// Populate resource details
 	response.Resource.Schedule = schedules.FromDBType(m.DbClient.GetScheduleByResourceId(response.Resource.Id))
 	response.Resource.Categories = categories.FromDBTypeArray(m.DbClient.GetCategoriesByResourceID(response.Resource.Id))
 	response.Resource.Notes = notes.FromNoteDBTypeArray(m.DbClient.GetNotesByResourceID(response.Resource.Id))
@@ -121,43 +107,27 @@ func (m *Manager) GetByID(w http.ResponseWriter, r *http.Request) {
 	response.Resource.Phones = phones.FromDBTypeArray(m.DbClient.GetPhonesByResourceID(response.Resource.Id))
 	response.Resource.Services = resources.ConvertServicesToResourceServices(m.DbClient.GetApprovedServicesByResourceId(response.Resource.Id), m.DbClient)
 
-	// Create and write the response
 	serviceResponse := &ServiceResponse{
 		Service: response,
 	}
 	writeJson(w, serviceResponse)
 }
 
-// ConvertHtmlToPdf method to convert HTML to PDF
-//
-//	@Summary		Convert HTML to PDF
-//	@Description	Converts HTML to PDF, with optional translation
-//	@Tags			services
-//	@Accept			multipart/form-data
-//	@Produce		application/pdf
-//	@Param			html			formData	string	true	"HTML content to convert"
-//	@Param			target_language	formData	string	false	"Target language for translation"
-//	@Success		200	{file}	file	"Generated PDF"
-//	@Router			/convert-html-to-pdf [post]
 func (m *Manager) ConvertHtmlToPdf(w http.ResponseWriter, r *http.Request) {
-	// Parse form data
 	if err := r.ParseForm(); err != nil {
 		log.Printf("%v", err)
 		common.WriteErrorJson(w, http.StatusBadRequest, "Error parsing form data")
 		return
 	}
 
-	// Extract HTML and target language from form
 	html := r.FormValue("html")
 	targetLanguage := r.FormValue("target_language")
 
-	// Validate input
 	if html == "" {
 		common.WriteErrorJson(w, http.StatusBadRequest, "HTML content is required")
 		return
 	}
 
-	// Process HTML (potentially translate)
 	processedHTML, err := m.processHTML(html, targetLanguage)
 	if err != nil {
 		log.Printf("%v", err)
@@ -165,7 +135,6 @@ func (m *Manager) ConvertHtmlToPdf(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert to PDF using PDFCrowd credentials
 	pdfData, err := m.htmlToPDF(processedHTML)
 	if err != nil {
 		log.Printf("%v", err)
@@ -173,18 +142,16 @@ func (m *Manager) ConvertHtmlToPdf(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set headers for PDF download
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("Content-Disposition", "attachment; filename=translation.pdf")
-	w.Write(pdfData)
+	if _, err = w.Write(pdfData); err != nil {
+		log.Printf("error writing PDF response: %v", err)
+	}
 }
 
-// processHTML handles potential translation
 func (m *Manager) processHTML(html, targetLanguage string) (string, error) {
-	// Supported languages
 	supportedLanguages := []string{"es", "tl", "zh-TW", "vi", "ar", "ru"}
 
-	// Check if translation is needed
 	languageSupported := false
 	for _, lang := range supportedLanguages {
 		if lang == targetLanguage {
@@ -193,51 +160,41 @@ func (m *Manager) processHTML(html, targetLanguage string) (string, error) {
 		}
 	}
 
-	// Translate if language is supported
 	if languageSupported {
-		// Check if translation credentials are available
 		if m.GoogleConfig.TranslateCredential == "" {
 			return "", fmt.Errorf("PDF translation service is not enabled right now. Please contact support or try again later")
 		}
-
 		return m.translateHTML(html, targetLanguage)
 	}
 
 	return html, nil
 }
 
-// translateHTML performs the translation of HTML content
 func (m *Manager) translateHTML(html, targetLanguage string) (string, error) {
-	// Supported languages map
 	supportedLanguages := map[string]bool{
 		"en": true, "es": true, "tl": true,
 		"zh-TW": true, "vi": true, "ar": true, "ru": true,
 	}
 
-	// Validate language
 	if !supportedLanguages[targetLanguage] {
 		return "", fmt.Errorf("unsupported language: %s", targetLanguage)
 	}
 
-	// Check if translation service is available
 	if m.TranslateService == nil {
 		return "", fmt.Errorf("translation service not available")
 	}
 
-	// Parse target language
 	target, err := language.Parse(targetLanguage)
 	if err != nil {
 		return "", fmt.Errorf("invalid language code: %v", err)
 	}
 
-	// Use injected translation service
 	ctx := context.Background()
 	translations, err := m.TranslateService.Translate(ctx, []string{html}, target)
 	if err != nil {
 		return "", err
 	}
 
-	// Return translated text
 	if len(translations) > 0 {
 		return translations[0], nil
 	}
@@ -245,28 +202,23 @@ func (m *Manager) translateHTML(html, targetLanguage string) (string, error) {
 	return "", fmt.Errorf("no translation returned")
 }
 
-// htmlToPDF converts HTML to PDF using PDFCrowd credentials
 func (m *Manager) htmlToPDF(html string) ([]byte, error) {
-	// Check if PDF service is available
 	if m.PDFService == nil {
 		return nil, fmt.Errorf("PDF service not available")
 	}
-
-	// Use injected PDF service
 	return m.PDFService.ConvertToPDF(html)
 }
 
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		log.Printf("%v", err)
-		common.WriteErrorJson(w, http.StatusInternalServerError, common.InternalServerErrorMessage)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }

--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -2,7 +2,7 @@ package users
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/MicahParks/keyfunc/v3"
@@ -23,7 +23,6 @@ func New(dbManager *db.Manager, jwtKeyfunc keyfunc.Keyfunc) *Manager {
 	return manager
 }
 
-// Get the currently authenticated user
 func (m *Manager) GetCurrent(w http.ResponseWriter, r *http.Request) {
 	dbUser, err := auth.GetUserFromRequest(r, m.JwtKeyfunc, m.DbClient)
 	if err != nil {
@@ -38,12 +37,13 @@ func (m *Manager) GetCurrent(w http.ResponseWriter, r *http.Request) {
 func writeJson(w http.ResponseWriter, object interface{}) {
 	output, err := json.Marshal(object)
 	if err != nil {
-		fmt.Println("error:", err)
+		log.Printf("error marshaling response: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(output)
-	if err != nil {
-		panic(err)
+	if _, err = w.Write(output); err != nil {
+		log.Printf("error writing response: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem
Every `writeJson` function across ~7 packages ends with `panic(err)` if `w.Write()` returns an error. A dropped TCP connection (client disconnects mid-response) will panic the goroutine. While Go's `net/http` recovers from panics in handlers, it logs a noisy stack trace and is not the correct pattern for a write error.

Affected packages: `bookmarks`, `categories`, `folders`, `news_articles`, `resources`, `services`, `users`, `changerequest`

## Fix
Replace `panic(err)` with `log.Printf` in all `writeJson` implementations. Write errors (dropped connections) are non-fatal and should be logged only.