### PR TITLE
[Medium] Fix: prepared statements never closed, causing connection leaks

### DIFF
--- a/internal/db/categories.go
+++ b/internal/db/categories.go
@@ -3,8 +3,9 @@ package db
 import (
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
 	"log"
+
+	"github.com/lib/pq"
 )
 
 type Category struct {
@@ -109,47 +110,49 @@ func (m *Manager) GetCategories(topLevel *bool) []*Category {
 	}
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
 func (m *Manager) GetCategoryServiceCounts() []*CategoryCount {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoryServiceCounts)
+	rows, err := m.DB.Query(categoryServiceCounts)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategoryCounts(rows)
 }
 
 func (m *Manager) GetCategoryResourceCounts() []*CategoryCount {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoryResourceCounts)
+	rows, err := m.DB.Query(categoryResourceCounts)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategoryCounts(rows)
 }
 
 func (m *Manager) GetCategoriesByFeatured() []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByFeaturedSql)
+	rows, err := m.DB.Query(categoriesByFeaturedSql)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
 func (m *Manager) GetSubCategoriesByID(categoryId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(subCategoriesByIDSql, categoryId)
+	rows, err := m.DB.Query(subCategoriesByIDSql, categoryId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
@@ -159,52 +162,54 @@ func (m *Manager) GetCategoryByID(categoryId int) *Category {
 }
 
 func (m *Manager) GetCategoriesByIDs(ids []int) []*Category {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(categoriesByIDsSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(ids))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(ids))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
 func (m *Manager) GetCategoriesByNames(names []string) []*Category {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(categoriesByNamesSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(names))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(names))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
 func (m *Manager) GetCategoriesByServiceID(serviceId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByServiceIDSql, serviceId)
+	rows, err := m.DB.Query(categoriesByServiceIDSql, serviceId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 
 func (m *Manager) GetCategoriesByResourceID(resourceId int) []*Category {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(categoriesByResourceIDSql, resourceId)
+	rows, err := m.DB.Query(categoriesByResourceIDSql, resourceId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanCategories(rows)
 }
 

--- a/internal/db/eligibilities.go
+++ b/internal/db/eligibilities.go
@@ -99,94 +99,98 @@ RETURNING id, name, feature_rank
 `
 
 func (m *Manager) GetEligibilities() []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(eligibilitiesSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query()
+	defer stmt.Close()
+	rows, err := stmt.Query()
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
-
 }
 
 func (m *Manager) GetEligibilitiesByCategoryId(categoryId *int) []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(eligibilitiesByCategoryIDSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(*categoryId)
+	defer stmt.Close()
+	rows, err := stmt.Query(*categoryId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
-
 }
 
 func (m *Manager) GetEligibilitiesByIDs(ids []int) []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(eligibilitiesByIDsSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(ids))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(ids))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 
 func (m *Manager) GetFeaturedEligibilities() []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(featuredEligibilitiesSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query()
+	defer stmt.Close()
+	rows, err := stmt.Query()
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 
 func (m *Manager) GetSubEligibilitiesByParentName(parentName string) []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(subEligibilitiesByParentNameSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(parentName)
+	defer stmt.Close()
+	rows, err := stmt.Query(parentName)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 
 func (m *Manager) GetSubEligibilitiesByParentID(parentID int) []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(subEligibilitiesByParentIDSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(parentID)
+	defer stmt.Close()
+	rows, err := stmt.Query(parentID)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 
@@ -194,7 +198,6 @@ func (m *Manager) UpdateEligibility(id int, name *string, featureRank *int) (*El
 	var eligibility Eligibility
 	var nameParam, featureRankParam interface{}
 
-	// Set parameters for the query
 	nameParam = nil
 	if name != nil {
 		nameParam = *name
@@ -205,7 +208,6 @@ func (m *Manager) UpdateEligibility(id int, name *string, featureRank *int) (*El
 		featureRankParam = *featureRank
 	}
 
-	// Execute the query
 	row := m.DB.QueryRow(updateEligibilitySql, nameParam, featureRankParam, id)
 	err := row.Scan(&eligibility.Id, &eligibility.Name, &eligibility.FeatureRank)
 
@@ -220,27 +222,28 @@ func (m *Manager) UpdateEligibility(id int, name *string, featureRank *int) (*El
 }
 
 func (m *Manager) GetEligibilitiesByNames(names []string) []*Eligibility {
-	var rows *sql.Rows
-	var err error
 	stmt, err := m.DB.Prepare(eligibilitiesByNamesSql)
 	if err != nil {
 		log.Printf("Prepare failed: %v\n", err)
 		return nil
 	}
-	rows, err = stmt.Query(pq.Array(names))
+	defer stmt.Close()
+	rows, err := stmt.Query(pq.Array(names))
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 
 func (m *Manager) GetEligibilitiesByServiceID(serviceId int) []*Eligibility {
-	var rows *sql.Rows
-	var err error
-	rows, err = m.DB.Query(eligibilitiesByServiceIDSql, serviceId)
+	rows, err := m.DB.Query(eligibilitiesByServiceIDSql, serviceId)
 	if err != nil {
 		log.Printf("%v\n", err)
+		return nil
 	}
+	defer rows.Close()
 	return scanEligibilities(rows)
 }
 


### PR DESCRIPTION
## Problem
In `internal/db/eligibilities.go` and `internal/db/categories.go`, `*sql.Stmt` objects created via `m.DB.Prepare()` are never closed. Each call to these functions leaks a server-side prepared statement handle. Over time this exhausts the DB connection pool.

## Fix
Add `defer stmt.Close()` immediately after each successful `m.DB.Prepare()` call. Also add `defer rows.Close()` where missing to ensure row cursors are released.