### PR TITLE
[codex] docs: add testing roadmap and priorities

### DIFF
--- a/docs/testing-implementation-roadmap.md
+++ b/docs/testing-implementation-roadmap.md
@@ -1,0 +1,144 @@
+# Testing Implementation Roadmap
+
+## Purpose
+This document turns the testing inventory and unit-test priorities into a phased implementation plan, with recommended batching, effort, and an initial coverage threshold strategy.
+
+## Guiding Principles
+- Keep the API as the primary integration test boundary.
+- Add unit tests where they reduce feedback time or make negative-path coverage much easier.
+- Favor small, mergeable batches over a large test rewrite.
+- Introduce coverage reporting early, but start with a modest gate that matches the current baseline.
+
+## Recommended Phases
+
+### Phase 1: Establish The Baseline
+Goal: make current testing measurable and stable enough to expand.
+
+Work:
+- Add a local coverage command for the default unit-test path.
+- Record baseline package-level and total line coverage.
+- Document current integration suite depth using the inventory in `docs/testing-inventory-gap-matrix.md`.
+- Identify and standardize how integration tests boot the app, since the current `init()` plus `go main()` pattern in `cmd/sheltertech-go/*_integration_test.go` is a likely source of flakiness.
+
+Deliverables:
+- `make coverage` or equivalent.
+- Initial coverage artifact such as `coverage.out`.
+- Short note in project docs on how to run unit, integration, and coverage commands.
+
+Estimate:
+- About 0.5 to 1 day.
+
+### Phase 2: First Unit-Test Slice
+Goal: add real unit tests in the highest-payoff internal packages.
+
+Work:
+- Replace placeholder tests in `internal/changerequest/manager_test.go` and `internal/services/manager_test.go`.
+- Add the minimum dependency seams needed to isolate those managers from `*db.Manager`.
+- Add a small set of helper-level tests in `internal/auth` and `internal/savedsearches` to raise coverage quickly with low implementation cost.
+
+Deliverables:
+- Real tests for `internal/changerequest` and `internal/services`.
+- Initial helper coverage for pure or mostly pure functions.
+- Repeatable test patterns for future manager tests.
+
+Estimate:
+- About 2 to 4 days.
+
+### Phase 3: Deepen High-Value API Integration Coverage
+Goal: strengthen the endpoint families that currently have the biggest gap between business importance and assertion depth.
+
+Work:
+- Expand `services`, `resources`, `saved_searches`, `bookmarks`, and `news_articles` integration suites first.
+- Add response-content assertions, not just status-code checks.
+- Add negative cases already implied by current handlers: invalid IDs, malformed JSON, not found, invalid query params, validation failures, and side-effect verification where applicable.
+- Prefer create-read-update-read and create-delete-read patterns for mutable resources.
+
+Deliverables:
+- Strengthened integration coverage in the highest-priority endpoint families.
+- Reduced dependence on fixed seeded IDs where practical.
+- Better error-body assertions for user-visible failures.
+
+Estimate:
+- About 3 to 5 days for the first endpoint batch.
+
+### Phase 4: Expand Branch-Heavy Unit Coverage
+Goal: cover the next layer of internal logic that is expensive or awkward to test only through the HTTP surface.
+
+Work:
+- Add unit tests for `internal/news_articles`, `internal/eligibilities`, `internal/savedsearches`, and `internal/folders`.
+- Cover explicit branch points and error mapping before adding broader CRUD happy-path duplication.
+- Keep seams narrow and package-local.
+
+Deliverables:
+- Solid unit coverage around validation, branching, and error translation.
+- Shared stubbing pattern that can be reused for other managers.
+
+Estimate:
+- About 3 to 5 days.
+
+### Phase 5: Broaden Remaining API And Unit Coverage
+Goal: close the most visible remaining gaps without over-testing low-value code.
+
+Work:
+- Add follow-on integration coverage for `users`, `phones`, `categories`, and `datathon`.
+- Add unit tests to `resources`, `categories`, `bookmarks`, and any small managers still unprotected.
+- Revisit auth-dependent scenarios once JWT behavior is testable in a stable way.
+
+Deliverables:
+- Coverage across the major endpoint families.
+- Fewer endpoint areas with only smoke-level protection.
+
+Estimate:
+- About 1 to 2 additional weeks, depending on auth and environment complexity.
+
+## Suggested Batch Order
+1. Coverage command and baseline reporting.
+2. `internal/changerequest` and `internal/services` unit tests.
+3. `internal/auth` and `internal/savedsearches` helper tests.
+4. Stronger integration tests for `services`, `resources`, and `saved_searches`.
+5. Stronger integration tests for `news_articles`, `folders`, and `bookmarks`.
+6. Unit tests for `news_articles`, `eligibilities`, `savedsearches`, and `folders`.
+7. Remaining package and endpoint backfill.
+
+## Coverage Recommendation
+
+### Metric
+- Use Go line coverage from the default unit-test suite first:
+  - `go test -coverprofile=coverage.out -covermode=atomic ./...`
+
+### Where To Enforce It
+- Add it locally through the `Makefile`.
+- Add it to `.github/workflows/ci.yml` in the existing `build` job or in a dedicated coverage job.
+- Keep integration coverage reporting separate at first; do not make merged unit-plus-integration coverage a blocker in the first pass.
+
+### Initial Threshold
+- Start with a modest threshold, likely in the 20% to 30% range for the default unit-test path.
+- Pick the final floor only after capturing the actual baseline.
+- Raise the threshold gradually as the first two or three implementation batches land.
+
+### Why This Threshold Range
+- Current unit coverage is near zero, so an aggressive threshold would either fail immediately or force low-value tests.
+- A modest initial gate creates accountability without distorting priorities.
+- Package-level visibility matters more than a single repo-wide number in the first iteration.
+
+## Definition Of Done For The First Milestone
+- Unit coverage is measurable locally and in CI.
+- Placeholder unit tests are replaced with real assertions.
+- At least three high-value endpoint families have materially stronger integration assertions.
+- The project has a documented, reusable pattern for adding both manager unit tests and API integration tests.
+
+## Overall Effort
+- Assessment and baseline setup: about 1 to 2 days.
+- First meaningful implementation milestone: about 1 week.
+- Broader expansion across most target areas: about 2 to 3 weeks total elapsed implementation time.
+
+## Autonomy
+- This work should be feasible to complete autonomously within this repository.
+- The current GitHub Actions configuration is in-repo, so local and CI coverage wiring should not require a separate config repository based on what is visible here.
+- The main unknowns are external policy constraints such as required checks, secret handling, or org-level GitHub settings, but those should not block the core implementation.
+
+## Recommended Next Execution Slice
+- Add coverage reporting to the local workflow and CI.
+- Implement real unit tests for `internal/changerequest` and `internal/services`.
+- Deepen integration tests for `cmd/sheltertech-go/services_integration_test.go` and `cmd/sheltertech-go/resources_integration_test.go`.
+- Reassess the new baseline after that slice before scaling to the rest of the endpoint families.

--- a/docs/testing-inventory-gap-matrix.md
+++ b/docs/testing-inventory-gap-matrix.md
@@ -1,0 +1,54 @@
+# Testing Inventory And Gap Matrix
+
+## Scope
+This document inventories the current automated tests in `sheltertech-go` and highlights the most important coverage gaps, with emphasis on unit coverage, API integration depth, and readiness for future coverage metrics.
+
+## Current State Summary
+- Unit coverage is effectively nonexistent. The only unit test files are placeholders in `internal/services/manager_test.go` and `internal/changerequest/manager_test.go`.
+- Integration coverage is API-first and concentrated in `cmd/sheltertech-go/*_integration_test.go`.
+- CI already runs unit and integration suites separately via `make test` and `make integration-test`.
+- Coverage reporting is not present locally or in CI.
+- Integration tests currently use a per-file `init()` plus `go main()` pattern, which is likely to be flaky and makes test setup harder to control.
+
+## Integration Test Inventory
+| Area | Test File | Current Coverage | Current Depth | Main Gaps | Priority |
+| --- | --- | --- | --- | --- | --- |
+| Categories | `cmd/sheltertech-go/categories_integration_test.go` | `GET /categories`, `GET /categories/{id}`, `GET /categories/subcategories/{id}`, `GET /categories/featured`, `GET /categories/counts` | Medium | Good payload parsing, but little negative coverage. Missing invalid ID, not found, invalid query handling, and `top_level` query coverage. Some assertions depend on seeded ordering and fixed data. | Medium |
+| Services | `cmd/sheltertech-go/services_integration_test.go` | `GET /services/{id}`, invalid ID, `POST /services/{id}/change_request` | Low to medium | Only one field is asserted on the read path. Missing not-found, malformed body, invalid change request type, and post-submit side-effect checks. | High |
+| Resources | `cmd/sheltertech-go/resources_integration_test.go` | `GET /resources/count` | Low | No `GET /resources/{id}` coverage, no invalid ID or error-path coverage, and no payload assertions beyond count parsing. | High |
+| Folders | `cmd/sheltertech-go/folders_integration_test.go` | Full CRUD plus invalid ID on read | Medium | Better than most suites because it verifies create then read and update then read. Still missing missing `user_id`, malformed body, 404 cases, and delete-followed-by-read validation. | High |
+| Saved Searches | `cmd/sheltertech-go/saved_searches_integration_test.go` | `GET`, `POST`, `GET /{id}`, `DELETE`, invalid ID | Medium | Mostly happy-path CRUD. Missing invalid categories and eligibilities, missing `user_id`, malformed JSON, delete verification, and response-content assertions beyond IDs. | High |
+| Bookmarks | `cmd/sheltertech-go/bookmarks_integration_test.go` | Bad query case, lookup error case, skipped auth tests | Low | No working happy-path CRUD coverage and auth scenarios are skipped. This area has meaningful functional exposure with very little test protection. | High |
+| News Articles | `cmd/sheltertech-go/news_articles_integration_test.go` | `GET`, `POST`, `PUT`, `DELETE`, invalid IDs for update and delete | Medium | Good endpoint spread, but assertions remain shallow. Missing invalid body tests, not-found tests, `active` query behavior, unexpected query param validation, and response field verification. | High |
+| Eligibilities | `cmd/sheltertech-go/eligibilities_integration_test.go` | `GET`, filtered `GET`, `GET /{id}`, featured, subeligibilities, update | Medium to high | This is one of the more detailed suites. Still missing several negative cases already encoded in handlers: invalid `category_id`, unexpected query params, duplicate-name updates, constraint violations, and missing `id` or `name` for subeligibilities. | Medium |
+| Users | `cmd/sheltertech-go/users_integration_test.go` | `GET /users/current` without auth and with dummy auth header | Low | No validated success path, no response payload assertions, and behavior is environment-dependent when JWT verification changes. | Medium to high |
+| Datathon | `cmd/sheltertech-go/datathon_integration_test.go` | Two dataset endpoints | Low | Likely smoke-level only. Missing payload shape checks, content sanity checks, and negative behavior if upstream assumptions change. | Medium |
+| Phones | `cmd/sheltertech-go/phones_integration_test.go` | Delete endpoint | Low | Very narrow endpoint coverage. Missing invalid ID, not-found, and successful delete verification. | Medium |
+| Swagger | `cmd/sheltertech-go/swagger_integration_test.go` | Swagger docs endpoint | Low | Mostly smoke coverage, which is probably fine. | Low |
+| Metrics | `cmd/sheltertech-go/metrics_integration_test.go` | Prometheus metrics endpoint | Low | Mostly smoke coverage, which is probably fine unless metrics format stability matters. | Low |
+
+## Unit Test Inventory
+| Package | Current State | Gap |
+| --- | --- | --- |
+| `internal/services` | Placeholder unit test only | No coverage for request parsing, DB error handling, or large response composition logic. |
+| `internal/changerequest` | Placeholder unit test only | No coverage for JSON parsing, error mapping, request validation, or submit behavior. |
+| Remaining `internal/*` packages | No unit tests present | Most business logic currently relies on integration tests to detect regressions. |
+
+## Cross-Cutting Gaps
+- Very little explicit verification of error response bodies and error-message consistency across endpoints.
+- Many tests still validate status codes without validating response payload semantics.
+- Several integration suites depend on seeded database records or fixed IDs, which increases brittleness.
+- Auth-protected paths are under-tested because JWT-related behavior is environment-sensitive.
+- There is no reusable integration test harness for server startup, seeded data management, or teardown.
+- There is no coverage baseline to show whether additional tests are actually improving confidence.
+
+## Highest-Value Gaps To Address First
+1. Strengthen low-depth but high-value API areas: `services`, `resources`, `bookmarks`, `saved_searches`, and `news_articles`.
+2. Add negative API scenarios already implied by handler code: invalid IDs, malformed bodies, unexpected query params, not-found paths, and validation failures.
+3. Replace or centralize the current integration startup pattern so the suite is stable enough to scale.
+4. Add unit tests around the most branch-heavy managers so regressions can be caught without booting the whole server.
+
+## Notes For Follow-On Coverage Work
+- The current layout supports an API-first testing strategy well, but it needs deeper assertions and more deliberate negative coverage.
+- Unit coverage should focus on handler and manager logic with narrow DB seams, not on trying to fully mock the entire `db.Manager`.
+- A first coverage metric should target the default `go test ./...` path and treat integration coverage as a later expansion.

--- a/docs/unit-test-target-priorities.md
+++ b/docs/unit-test-target-priorities.md
@@ -1,0 +1,61 @@
+# Unit Test Target Priorities
+
+## Purpose
+This document prioritizes the internal packages that should receive unit tests first, based on regression risk, branching complexity, and the likely payoff compared with additional integration-only coverage.
+
+## Prioritization Criteria
+- Business importance of the endpoint or flow.
+- Amount of branching, validation, or error mapping in the manager.
+- Likelihood that a unit test can isolate logic faster than an integration test.
+- Amount of existing integration coverage already protecting the same behavior.
+- Expected difficulty of introducing test seams around `*db.Manager`.
+
+## Priority 0: Start Here
+| Package | Why It Is First | First Tests To Add | Testability Notes |
+| --- | --- | --- | --- |
+| `internal/changerequest` | Small surface area, explicit placeholder test, and meaningful request branching. Good early win. | Invalid JSON body, unsupported or missing change request type, DB lookup failure, submit failure, success path returns `201`. | Likely needs a very small interface exposing `GetServiceById` and `SubmitChangeRequest`. |
+| `internal/services` | High-value endpoint with heavy response composition and multiple DB calls. Placeholder test already exists. | Invalid ID returns `400`, DB lookup error returns `400`, success response includes expected service wrapper fields, optional program and resource branches behave correctly. | Best tested by extracting a narrow dependency interface rather than mocking all of `db.Manager`. |
+| `internal/news_articles` | Good amount of branching and validation, plus strong overlap with API behavior that should be validated more cheaply in unit tests. | Invalid create body, unexpected query params, invalid update/delete IDs, not-found update/delete, DB error mapping, successful create/update serialization. | A focused interface for article CRUD is enough. |
+| `internal/eligibilities` | Branch-heavy logic with several explicit error-mapping paths that are expensive to exhaust via integration only. | Invalid `category_id`, unexpected query params, invalid body, update duplicate-name path, update not-found path, subeligibilities missing both `id` and `name`, successful filtered fetch. | Good candidate once a seam exists for read and update methods. |
+
+## Priority 1: High Value After The First Slice
+| Package | Why It Matters | First Tests To Add | Testability Notes |
+| --- | --- | --- | --- |
+| `internal/savedsearches` | Dense validation and translation logic. Likely one of the best places to add meaningful unit coverage. | Invalid JSON, invalid category names, invalid eligibility names, success path builds DB query correctly, delete invalid ID handling. | Also includes helper functions that can be tested immediately without mocks. |
+| `internal/folders` | Straightforward CRUD branch coverage with several status-handling paths that should be locked down. | Missing or invalid `user_id`, create failure, created record missing after create, get invalid ID, get not found, update failure, delete failure. | Easy to cover once CRUD methods are abstracted behind a small interface. |
+| `internal/users` | Current integration tests do not truly validate the authenticated success path. | Auth failure returns `400`, successful user lookup returns serialized user payload. | May be easiest to test in combination with `internal/auth` helpers or after introducing an auth seam. |
+| `internal/resources` | Important read path with response composition and an independent count endpoint. | Invalid ID handling, count DB error path, response composition for `GetByID`, service/category/phone enrichment. | Similar seam shape to `internal/services`. |
+| `internal/auth` | Header parsing and request-to-user resolution are currently under-protected and influence user-facing behavior. | Missing authorization header, malformed bearer header, JWT parse failure, unknown user external ID. | `getAuthToken` is a low-effort pure helper target; `GetUserFromRequest` may need a seam or careful fixture setup. |
+
+## Priority 2: Useful But Not Urgent
+| Package | Why It Is Later | First Tests To Add | Testability Notes |
+| --- | --- | --- | --- |
+| `internal/categories` | Important endpoint family, but current integration tests already cover its main happy paths more than most areas. | `top_level` query parsing, count aggregation and sorting, invalid ID behavior in `GetByID` and `GetSubCategoriesByID`. | Good medium-effort candidate because the count aggregation logic is deterministic. |
+| `internal/bookmarks` | Coverage is currently weak, but auth behavior may complicate early unit work depending on how deep the handler relies on request context. | Bad `user_id`, get-by-ID error mapping, create/update/delete happy and error paths. | Worth moving earlier if auth seams become simple. |
+| `internal/phones` | Small surface area. | Delete invalid ID, delete DB failure, successful delete status. | Fast to add once a seam exists. |
+| `internal/datathon` | Low branching and likely mostly passthrough behavior. | Dataset retrieval success and DB error behavior if any. | Lower payoff than the managers above. |
+
+## Low-Effort Coverage Wins
+- `internal/auth/getAuthToken`: pure header parsing with no DB dependency.
+- `internal/savedsearches/getEligibilityIdsFromDbSavedSearches`: deterministic helper.
+- `internal/savedsearches/getCategoryIdsFromDbSavedSearches`: deterministic helper.
+- `internal/savedsearches/diffStringSlices`: deterministic helper.
+- Any DTO conversion helpers that contain nontrivial branching or nil handling.
+
+## Suggested Implementation Order
+1. Convert the placeholder tests in `internal/changerequest/manager_test.go` and `internal/services/manager_test.go` into real tests.
+2. Add minimal dependency interfaces needed to unit test `internal/changerequest`, `internal/services`, and `internal/news_articles`.
+3. Add helper-level tests in `internal/auth` and `internal/savedsearches` for quick coverage gains.
+4. Move next into `internal/eligibilities` and `internal/savedsearches`, which both have strong negative-case potential.
+5. Fill in CRUD-oriented managers like `internal/folders`, then cover simpler packages such as `internal/resources`, `internal/categories`, and `internal/phones`.
+
+## Expected Effort
+- Priority 0 package test harness and first tests: about 2 to 4 working days.
+- Priority 1 packages: about 3 to 5 more working days, depending on how much seam extraction is needed.
+- Priority 2 and helper backfill: about 2 to 3 more working days.
+
+## Recommended Testing Pattern
+- Prefer table-driven tests for request validation and status mapping.
+- Introduce package-local interfaces with only the DB methods a manager actually uses.
+- Keep unit tests focused on observable behavior: status code, response body, branch selection, and arguments passed to dependencies.
+- Avoid broad fake implementations of the full `db.Manager`; they will be harder to maintain than narrow stubs.


### PR DESCRIPTION
## Summary

- Add a testing inventory and gap matrix for the current integration and unit test coverage.
- Add unit-test target priorities for the highest-value internal packages.
- Add a phased testing implementation roadmap with baseline coverage recommendations and suggested execution order.

## Why

These docs capture a practical path for expanding test coverage in small, reviewable batches. They should make it easier to pick the first implementation slice, add coverage reporting, and prioritize unit tests where they reduce regression risk most.

## Validation

- Ran `git diff --check HEAD^ HEAD` for whitespace validation.
- No code tests run because this PR only adds markdown documentation.